### PR TITLE
fix(ci): set codecov passing thresholds to 0

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,6 +15,6 @@ coverage:
         threshold: 0%
         branches: 
           - main
-        if_ci_failed: error #success, failure, error, ignore
+        if_ci_failed: error
         informational: true
         only_pulls: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 0%
+        threshold: 0%
+        if_ci_failed: error
+        branches: 
+          - main
+        informational: true
+        only_pulls: false
+    patch:
+      default:
+        target: 0%
+        threshold: 0%
+        branches: 
+          - main
+        if_ci_failed: error #success, failure, error, ignore
+        informational: true
+        only_pulls: false


### PR DESCRIPTION
Mark codecov as informational and set thresholds to 0,
so it should not fail when PRs have insufficient coverage.
