### PR TITLE
feat(node-naming): priority system for determining node names

### DIFF
--- a/substrate-api/src/context.rs
+++ b/substrate-api/src/context.rs
@@ -10,7 +10,8 @@ use tracing::{span, Level};
 
 use crate::error::Result;
 use crate::io::{
-    FlatLen, Flatten, HasNameTree, LayoutDataBuilder, LayoutType, NodeContext, Port, SchematicType,
+    FlatLen, Flatten, HasNameTree, LayoutDataBuilder, LayoutType, NodeContext, NodePriority, Port,
+    SchematicType,
 };
 use crate::layout::element::RawCell;
 use crate::layout::error::{GdsExportError, LayoutError};
@@ -172,7 +173,7 @@ impl<PDK: Pdk> Context<PDK> {
         inner_mut.schematic.gen.generate(block.clone(), move || {
             let mut node_ctx = NodeContext::new();
             let io = block.io();
-            let nodes = node_ctx.nodes(io.len());
+            let nodes = node_ctx.nodes(io.len(), NodePriority::Io);
             let (io_data, nodes_rest) = io.instantiate(&nodes);
             assert!(nodes_rest.is_empty());
             let cell_name = block.name();

--- a/substrate-api/src/schematic/mod.rs
+++ b/substrate-api/src/schematic/mod.rs
@@ -16,7 +16,7 @@ use crate::context::Context;
 use crate::error::Result;
 use crate::generator::Generator;
 use crate::io::{
-    Connect, FlatLen, Flatten, HasNameTree, NameBuf, Node, NodeContext, NodeUf, Port,
+    Connect, FlatLen, Flatten, HasNameTree, NameBuf, Node, NodeContext, NodePriority, NodeUf, Port,
     SchematicData, SchematicType,
 };
 use crate::pdk::Pdk;
@@ -59,7 +59,7 @@ impl<PDK: Pdk, T: Block> CellBuilder<PDK, T> {
         let mut roots = HashMap::with_capacity(self.node_names.len());
         let mut uf = self.node_ctx.into_inner();
         for &node in self.node_names.keys() {
-            let root = uf.find(node);
+            let root = uf.probe_value(node).unwrap().source;
             roots.insert(node, root);
         }
         RawCell {
@@ -78,7 +78,7 @@ impl<PDK: Pdk, T: Block> CellBuilder<PDK, T> {
         let cell = self.ctx.generate_schematic(block.clone());
         let io = block.io();
 
-        let ids = self.node_ctx.nodes(io.len());
+        let ids = self.node_ctx.nodes(io.len(), NodePriority::Auto);
         let (io_data, ids_rest) = block.io().instantiate(&ids);
         assert!(ids_rest.is_empty());
 


### PR DESCRIPTION
IOs have the highest priority (3).
Explicitly named signals have intermediate priority (2).
Automatically-named signals have the lowest priority (1).

Signals with automatically-generated names include the IOs
of subcells instantiated by a higher-level cell.
