### PR TITLE
feat(proc-macros): proc macros find substrate crate location

### DIFF
--- a/pdks/sky130pdk/Cargo.toml
+++ b/pdks/sky130pdk/Cargo.toml
@@ -2,7 +2,6 @@
 name = "sky130pdk"
 version = "0.0.0"
 edition = "2021"
-publish = false
 
 [dependencies]
 substrate = { version = "0.0.0", registry = "substrate", path = "../../substrate" }

--- a/substrate/src/ios.rs
+++ b/substrate/src/ios.rs
@@ -1,0 +1,17 @@
+//! Common IO types.
+
+use crate::io::{InOut, Input, Signal};
+use crate::Io;
+
+/// The interface to a standard 4-terminal MOSFET.
+#[derive(Debug, Default, Clone, Io)]
+pub struct MosIo {
+    /// The drain.
+    pub d: InOut<Signal>,
+    /// The gate.
+    pub g: Input<Signal>,
+    /// The source.
+    pub s: InOut<Signal>,
+    /// The body.
+    pub b: InOut<Signal>,
+}

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -5,6 +5,8 @@ pub use codegen::*;
 pub use geometry;
 pub use substrate_api::*;
 
+pub mod ios;
+
 // Re-exports for macros.
 #[doc(hidden)]
 pub use duplicate;


### PR DESCRIPTION
Proc macros find the substrate or substrate_api crate based on
the Cargo.toml of the crate invoking the macro.

feat(proc-macros): macros respect field and struct visibilities
feat(proc-macros): allow missing docs on generated structs
feat(mos): add standard 4-terminal MosIo
