### PR TITLE
feat(scir-instances): allow Substrate users to instantiate raw SCIR instances

### DIFF
--- a/libs/spice/src/parser/mod.rs
+++ b/libs/spice/src/parser/mod.rs
@@ -124,7 +124,7 @@ impl Parser {
 
                 match kind {
                     'R' => Line::Component(Component::Res(Res {
-                        name: self.buffer[0].try_ident()?.substr(1..).clone().into(),
+                        name: self.buffer[0].try_ident()?.clone(),
                         pos: self.buffer[1].try_ident()?.clone(),
                         neg: self.buffer[2].try_ident()?.clone(),
                         value: self.buffer[3].try_ident()?.clone(),
@@ -162,7 +162,7 @@ impl Parser {
                         }
 
                         Line::Component(Component::Instance(Instance {
-                            name: self.buffer[0].try_ident()?.substr(1..).clone().into(),
+                            name: self.buffer[0].try_ident()?.clone(),
                             ports,
                             child,
                             params,

--- a/libs/spice/src/parser/tests.rs
+++ b/libs/spice/src/parser/tests.rs
@@ -64,7 +64,7 @@ fn parse_dff() {
             let c = &components[10];
             match c {
                 Component::Instance(inst) => {
-                    assert_eq!(inst.name, "10".into());
+                    assert_eq!(inst.name, "X10".into());
                     assert_eq!(inst.child, "sky130_fd_pr__pfet_01v8".into());
                     assert_eq!(
                         inst.ports,

--- a/scir/src/lib.rs
+++ b/scir/src/lib.rs
@@ -250,6 +250,13 @@ impl Concat {
     }
 }
 
+impl FromIterator<Slice> for Concat {
+    fn from_iter<T: IntoIterator<Item = Slice>>(iter: T) -> Self {
+        let parts = iter.into_iter().collect();
+        Self { parts }
+    }
+}
+
 impl From<Vec<Slice>> for Concat {
     #[inline]
     fn from(value: Vec<Slice>) -> Self {

--- a/substrate/src/schematic/mod.rs
+++ b/substrate/src/schematic/mod.rs
@@ -734,7 +734,7 @@ impl<T: HasSchematic> Instance<T> {
 }
 
 /// A primitive device.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub enum PrimitiveDevice {
     /// An ideal 2-terminal resistor.
     Res2 {
@@ -755,6 +755,11 @@ pub enum PrimitiveDevice {
         cell: ArcStr,
         /// Parameters to the cell being instantiated.
         params: HashMap<ArcStr, scir::Expr>,
+    },
+    /// An instance of a SCIR cell.
+    ScirInstance {
+        lib: Arc<scir::Library>,
+        instance: scir::Instance,
     },
 }
 

--- a/substrate/src/schematic/mod.rs
+++ b/substrate/src/schematic/mod.rs
@@ -757,9 +757,20 @@ pub enum PrimitiveDevice {
         params: HashMap<ArcStr, scir::Expr>,
     },
     /// An instance of a SCIR cell.
+    ///
+    /// Substrate does not support creating
+    /// SCIR instances with parameters.
     ScirInstance {
+        /// The SCIR library containing the child cell.
         lib: Arc<scir::Library>,
-        instance: scir::Instance,
+        /// The ID of the child cell.
+        cell: scir::CellId,
+        /// The name of the instance.
+        ///
+        /// This need not be related to the name of the child cell.
+        name: ArcStr,
+        /// The connections to the ports of the child cell.
+        connections: HashMap<ArcStr, Vec<Node>>,
     },
 }
 

--- a/tests/data/spice/buffer.spice
+++ b/tests/data/spice/buffer.spice
@@ -1,0 +1,11 @@
+* CMOS buffer
+
+.subckt buffer din dout vdd vss
+X0 din dinb vdd vss inverter
+X1 dinb dout vdd vss inverter
+.ends
+
+.subckt inverter din dout vdd vss
+X0 dout din vss vss sky130_fd_pr__nfet_01v8 w=2 l=0.15
+X1 dout din vdd vdd sky130_fd_pr__pfet_01v8 w=4 l=0.15
+.ends

--- a/tests/src/hard_macro.rs
+++ b/tests/src/hard_macro.rs
@@ -1,5 +1,12 @@
 use crate::shared::buffer::BufferIo;
+use arcstr::ArcStr;
 use serde::{Deserialize, Serialize};
+use sky130pdk::Sky130OpenPdk;
+use spice::parser::conv::ScirConverter;
+use std::collections::HashMap;
+use std::sync::Arc;
+use substrate::io::{Flatten, Node};
+use substrate::schematic::{HasSchematic, HasSchematicImpl, PrimitiveDevice};
 use substrate::Block;
 
 #[derive(Block, Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
@@ -8,3 +15,54 @@ use substrate::Block;
     // schematic(path = "/path/to/schematic", fmt = "spectre")
 )]
 pub struct BufferHardMacro;
+
+impl HasSchematic for BufferHardMacro {
+    type Data = ();
+}
+
+impl HasSchematicImpl<Sky130OpenPdk> for BufferHardMacro {
+    fn schematic(
+        &self,
+        io: &<<Self as substrate::block::Block>::Io as substrate::io::SchematicType>::Data,
+        cell: &mut substrate::schematic::CellBuilder<Sky130OpenPdk, Self>,
+    ) -> substrate::error::Result<Self::Data> {
+        let path = crate::paths::test_data("spice/buffer.spice");
+        let parsed = spice::parser::Parser::parse_file(path).unwrap();
+        let mut conv = ScirConverter::new("buffer", &parsed.ast);
+        conv.blackbox("sky130_fd_pr__nfet_01v8");
+        conv.blackbox("sky130_fd_pr__pfet_01v8");
+        let lib = Arc::new(conv.convert().unwrap());
+        let cell_id = lib.cell_id_named("buffer");
+        let connections: HashMap<ArcStr, Vec<Node>> = HashMap::from_iter([
+            ("din".into(), io.din.flatten_vec()),
+            ("dout".into(), io.dout.flatten_vec()),
+            ("vdd".into(), io.vdd.flatten_vec()),
+            ("vss".into(), io.vss.flatten_vec()),
+        ]);
+        cell.add_primitive(PrimitiveDevice::ScirInstance {
+            lib,
+            cell: cell_id,
+            name: "buffer_hard_macro_inner".into(),
+            connections,
+        });
+        Ok(())
+    }
+}
+
+#[test]
+fn export_hard_macro() {
+    use crate::shared::pdk::sky130_open_ctx;
+
+    let ctx = sky130_open_ctx();
+    let lib = ctx.export_scir(BufferHardMacro);
+    assert_eq!(lib.scir.cells().count(), 3);
+
+    println!("SCIR Library:\n{:?}", lib.scir);
+
+    let mut buf: Vec<u8> = Vec::new();
+    let includes = Vec::new();
+    let netlister = spectre::netlist::Netlister::new(&lib.scir, &includes, &mut buf);
+    netlister.export().unwrap();
+    let string = String::from_utf8(buf).unwrap();
+    println!("Netlist:\n{}", string);
+}

--- a/tests/src/shared/pdk/mod.rs
+++ b/tests/src/shared/pdk/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use scir::Expr;
 use serde::{Deserialize, Serialize};
-use sky130pdk::Sky130CommercialPdk;
+use sky130pdk::{Sky130CommercialPdk, Sky130OpenPdk};
 use spectre::Spectre;
 use substrate::block::Block;
 use substrate::context::Context;
@@ -136,6 +136,24 @@ pub fn sky130_commercial_ctx() -> Context<Sky130CommercialPdk> {
         .expect("the SKY130_COMMERCIAL_PDK_ROOT environment variable must be set");
     Context::builder()
         .pdk(Sky130CommercialPdk::new(pdk_root))
+        .with_simulator(Spectre::default())
+        .build()
+}
+
+/// Create a new Substrate context for the SKY130 open-source PDK.
+///
+/// Sets the PDK root to the value of the `SKY130_OPEN_PDK_ROOT`
+/// environment variable.
+///
+/// # Panics
+///
+/// Panics if the `SKY130_OPEN_PDK_ROOT` environment variable is not set,
+/// or if the value of that variable is not a valid UTF-8 string.
+pub fn sky130_open_ctx() -> Context<Sky130OpenPdk> {
+    let pdk_root = std::env::var("SKY130_OPEN_PDK_ROOT")
+        .expect("the SKY130_OPEN_PDK_ROOT environment variable must be set");
+    Context::builder()
+        .pdk(Sky130OpenPdk::new(pdk_root))
         .with_simulator(Spectre::default())
         .build()
 }


### PR DESCRIPTION
Allow Substrate schematic generators to instantiate cells
from an externally-loaded SCIR library.