### PR TITLE
feat(proc-macros): codegen for schematic hard macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,9 +523,11 @@ dependencies = [
  "convert_case 0.6.0",
  "darling 0.20.1",
  "proc-macro-crate 1.3.1",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "serde",
+ "sky130pdk",
  "substrate",
  "syn 2.0.23",
 ]
@@ -2301,6 +2303,7 @@ dependencies = [
  "opacity",
  "scir",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -2335,6 +2338,7 @@ dependencies = [
  "rust_decimal_macros",
  "scir",
  "serde",
+ "spice",
  "thiserror",
  "toml 0.7.6",
  "tracing",

--- a/Justfile
+++ b/Justfile
@@ -4,7 +4,7 @@ _default:
     @just --list
 
 # Runs clippy on the source code
-check:
+check: gen-examples
   cargo clippy --locked --all-features --all-targets -- -D warnings
 
 # Runs clippy on the source code, attempting to fix any errors
@@ -24,10 +24,10 @@ check-fmt:
 test: gen-examples test-examples
   cargo test --locked
 
-check-all:
+check-all: gen-examples
     cargo hack --feature-powerset clippy --locked -- -D warnings
 
-check-docs:
+check-docs: gen-examples
     RUSTDOCFLAGS='-D warnings' RUSTFLAGS='-D warnings' cargo hack --all rustdoc --all-features --all-targets
 
 gen-examples:

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -10,12 +10,14 @@ syn = { version = "2", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
 proc-macro-crate = "1"
+proc-macro-error = "1"
 convert_case = "0.6"
 
 [dev-dependencies]
 arcstr = "1"
 serde = { version = "1", features = ["derive"] }
 substrate = { version = "<=0.2.0", registry = "substrate", path = "../substrate" }
+sky130pdk = { version = "<=0.2.0", registry = "substrate", path = "../pdks/sky130pdk" }
 
 [lib]
 proc-macro = true

--- a/codegen/src/block/mod.rs
+++ b/codegen/src/block/mod.rs
@@ -9,11 +9,18 @@ pub mod layout;
 pub mod schematic;
 
 #[derive(Debug, FromDeriveInput)]
-#[darling(attributes(substrate), supports(struct_any, enum_any))]
+#[darling(
+    attributes(substrate),
+    supports(struct_any, enum_any),
+    forward_attrs(substrate, schematic)
+)]
 pub struct BlockInputReceiver {
     ident: syn::Ident,
     generics: syn::Generics,
     io: syn::Type,
+    #[darling(multiple)]
+    #[allow(unused)]
+    schematic: Vec<darling::util::Ignored>,
 }
 
 impl ToTokens for BlockInputReceiver {
@@ -23,6 +30,7 @@ impl ToTokens for BlockInputReceiver {
             ref ident,
             ref generics,
             ref io,
+            ..
         } = *self;
 
         let (imp, ty, wher) = generics.split_for_impl();

--- a/codegen/src/block/schematic.rs
+++ b/codegen/src/block/schematic.rs
@@ -1,5 +1,5 @@
 use darling::ast::{Fields, Style};
-use darling::{ast, FromDeriveInput, FromField, FromVariant};
+use darling::{ast, FromDeriveInput, FromField, FromMeta, FromVariant};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use syn::parse_quote;
@@ -232,6 +232,121 @@ impl ToTokens for DataInputReceiver {
                     }
                 }
             }
+        };
+
+        tokens.extend(quote! {
+            #expanded
+        });
+    }
+}
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(substrate), supports(any))]
+pub struct HasSchematicImplInputReceiver {
+    ident: syn::Ident,
+    generics: syn::Generics,
+    #[allow(unused)]
+    io: syn::Type,
+    #[darling(multiple)]
+    schematic: Vec<SchematicHardMacro>,
+}
+
+#[derive(Debug, FromMeta)]
+pub struct SchematicHardMacro {
+    source: syn::Expr,
+    fmt: darling::util::SpannedValue<String>,
+    pdk: syn::Type,
+    name: String,
+}
+
+impl ToTokens for HasSchematicImplInputReceiver {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let substrate = substrate_ident();
+        let HasSchematicImplInputReceiver {
+            ref ident,
+            ref generics,
+            ref schematic,
+            ..
+        } = *self;
+
+        let (imp, ty, wher) = generics.split_for_impl();
+
+        let has_schematic = quote! {
+            impl #imp #substrate::schematic::HasSchematic for #ident #ty #wher {
+                type Data = ();
+            }
+        };
+
+        let has_schematic_impls = schematic.iter().map(|schematic| {
+            let SchematicHardMacro { source, fmt, pdk, name } = schematic;
+
+            let parsed_to_scir = quote! {
+                let mut conv = #substrate::spice::parser::conv::ScirConverter::new(::std::stringify!(#ident), &parsed.ast);
+
+                for prim in cell.ctx.pdk.pdk.schematic_primitives() {
+                    conv.blackbox(#substrate::arcstr::Substr::full(prim));
+                }
+
+                let lib = ::std::sync::Arc::new(conv.convert().unwrap());
+                let cell_id = lib.cell_id_named(#name);
+
+                (lib, cell_id)
+            };
+
+            // The SCIR token stream must create two variables:
+            // * lib, of type Arc<scir::Library>
+            // * cell_id, of type scir::CellId
+            // The token stream has access to source.
+            let scir = match fmt.as_str() {
+                "spice" => quote! {
+                    let parsed = #substrate::spice::parser::Parser::parse_file(source).unwrap();
+                    #parsed_to_scir
+                },
+                "inline-spice" | "inline_spice" => quote! {
+                    let parsed = #substrate::spice::parser::Parser::parse(source).unwrap();
+                    #parsed_to_scir
+                },
+                fmtstr => proc_macro_error::abort!(fmt.span(), "unsupported schematic hard macro format: `{}`", fmtstr),
+            };
+
+            quote! {
+                impl #imp #substrate::schematic::HasSchematicImpl<#pdk> for #ident #ty #wher {
+                    fn schematic(
+                        &self,
+                        io: &<<Self as #substrate::block::Block>::Io as #substrate::io::SchematicType>::Data,
+                        cell: &mut #substrate::schematic::CellBuilder<#pdk, Self>,
+                    ) -> #substrate::error::Result<Self::Data> {
+                        use #substrate::pdk::Pdk;
+
+                        let source = {
+                            #source
+                        };
+
+                        let (lib, cell_id) = { #scir };
+
+                        use #substrate::io::StructData;
+                        let connections: ::std::collections::HashMap<#substrate::arcstr::ArcStr, ::std::vec::Vec<#substrate::io::Node>> =
+                            ::std::collections::HashMap::from_iter(io.fields().into_iter().map(|f| {
+                                let nodes = io.field_nodes(&f).unwrap();
+                                (f, nodes)
+                            }));
+
+                        cell.add_primitive(#substrate::schematic::PrimitiveDevice::ScirInstance {
+                            lib,
+                            cell: cell_id,
+                            name: #substrate::arcstr::literal!(#name),
+                            connections,
+                        });
+                        Ok(())
+                    }
+                }
+            }
+        });
+
+        let expanded = quote! {
+            #has_schematic
+
+            #(#has_schematic_impls)*
         };
 
         tokens.extend(quote! {

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -18,6 +18,7 @@ use pdk::supported_pdks::supported_pdks_impl;
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use proc_macro_crate::{crate_name, FoundCrate};
+use proc_macro_error::proc_macro_error;
 use quote::quote;
 use sim::simulator_tuples_impl;
 use syn::Ident;
@@ -365,6 +366,59 @@ pub fn derive_transform_mut(input: TokenStream) -> TokenStream {
 
     let expanded = derive_trait(&config, receiver);
     proc_macro::TokenStream::from(expanded)
+}
+
+/// Derives `substrate::schematic::HasSchematicImpl` for any Substrate block.
+///
+/// This turns the block into a schematic hard macro.
+///
+/// This macro only works on Substrate blocks,
+/// so you must also add a `#[derive(Block)]` attribute
+/// or implement `Block` manually.
+///
+/// # Arguments
+///
+/// This macro requires the following arguments (see [Supported formats](#supported-formats) for more details):
+/// * `source`: The source from which to read the contents of this block's schematic.
+/// * `name`: The name of the block's contents in `source`. For example, if
+///   source is a SPICE netlist, name should be set to the name of the desired
+///   subcircuit in that netlist.
+/// * `fmt`: The netlist format.
+/// * `pdk`: The PDK to which source corresponds.
+///
+/// # Supported formats
+///
+/// The following formats are supported:
+///
+/// | `fmt`        | `source`                                              |
+/// |--------------|-------------------------------------------------------|
+/// | spice        | An expression that evaluates to a file path.          |
+/// | inline-spice | An expression that evaluates to a String-like object. |
+///
+/// Note that expressions can be arbitrary Rust expressions. Here are some examples:
+/// * `fmt = "\"/path/to/netlist.spice\""` (note that you need the escaped quotes to make this a
+/// string literal).
+/// * `fmt = "function_that_returns_path()"`
+/// * `fmt = "function_with_arguments_that_returns_path(\"my_argument\")"`
+///
+/// # Examples
+///
+/// ```
+#[doc = include_str!("../build/docs/prelude.rs.hidden")]
+#[doc = include_str!("../build/docs/block/buffer_io_simple.rs.hidden")]
+#[doc = include_str!("../build/docs/block/buffer_hard_macro.rs")]
+/// ```
+#[proc_macro_error]
+#[proc_macro_derive(HasSchematicImpl, attributes(substrate))]
+pub fn derive_has_schematic_impl(input: TokenStream) -> TokenStream {
+    let receiver = block::schematic::HasSchematicImplInputReceiver::from_derive_input(
+        &parse_macro_input!(input as DeriveInput),
+    );
+    let receiver = handle_error!(receiver);
+    quote!(
+        #receiver
+    )
+    .into()
 }
 
 pub(crate) fn substrate_ident() -> TokenStream2 {

--- a/docs/api/code/block/buffer_hard_macro.rs
+++ b/docs/api/code/block/buffer_hard_macro.rs
@@ -1,0 +1,21 @@
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, Block, HasSchematicImpl)]
+#[substrate(io = "BufferIo")]
+#[substrate(schematic(
+    source = "r###\"
+        * CMOS buffer
+
+        .subckt buffer din dout vdd vss
+        X0 din dinb vdd vss inverter
+        X1 dinb dout vdd vss inverter
+        .ends
+
+        .subckt inverter din dout vdd vss
+        X0 dout din vss vss sky130_fd_pr__nfet_01v8 w=2 l=0.15
+        X1 dout din vdd vdd sky130_fd_pr__pfet_01v8 w=4 l=0.15
+        .ends
+    \"###",
+    name = "buffer",
+    fmt = "inline-spice",
+    pdk = "Sky130OpenPdk"
+))]
+pub struct BufferInlineHardMacro;

--- a/docs/api/code/prelude.rs
+++ b/docs/api/code/prelude.rs
@@ -12,5 +12,6 @@ use substrate::pdk::layers::LayerId;
 use substrate::pdk::{Pdk, PdkLayers};
 use substrate::supported_pdks;
 use substrate::{
-    DerivedLayerFamily, DerivedLayers, Io, Layer, LayerFamily, Layers, LayoutData, LayoutType,
+    Block, DerivedLayerFamily, DerivedLayers, Io, Layer, LayerFamily, Layers, LayoutData, LayoutType, HasSchematicImpl,
 };
+use sky130pdk::{Sky130CommercialPdk, Sky130OpenPdk};

--- a/libs/spice/Cargo.toml
+++ b/libs/spice/Cargo.toml
@@ -9,3 +9,4 @@ opacity = { version = "0.1.0", path = "../../libs/opacity", registry = "substrat
 arcstr = { version = "1", features = ["serde", "substr-usize-indices"] }
 nom = "7"
 thiserror = "1"
+tracing = "0.1"

--- a/scir/src/lib.rs
+++ b/scir/src/lib.rs
@@ -489,7 +489,13 @@ impl Library {
     ///
     /// Panics if no cell has the given name.
     pub fn cell_id_named(&self, name: &str) -> CellId {
-        *self.name_map.get(name).unwrap()
+        match self.name_map.get(name) {
+            Some(&cell) => cell,
+            None => {
+                tracing::error!("no cell named `{}` in SCIR library `{}`", name, self.name);
+                panic!("no cell named `{}` in SCIR library `{}`", name, self.name);
+            }
+        }
     }
 
     /// Iterates over the `(id, cell)` pairs in this library.

--- a/substrate/Cargo.toml
+++ b/substrate/Cargo.toml
@@ -26,6 +26,7 @@ opacity = { version = "0.1.0", path = "../libs/opacity", registry = "substrate" 
 scir = { version = "0.1.0", registry = "substrate", path = "../scir" }
 pathtree = { version = "0.1.0", registry = "substrate", path = "../libs/pathtree" }
 uniquify = { version = "0.1.0", registry = "substrate", path = "../libs/uniquify" }
+spice = { version = "0.0.0", registry = "substrate", path = "../libs/spice" }
 
 [dev-dependencies]
 toml = "0.7"

--- a/substrate/src/io/mod.rs
+++ b/substrate/src/io/mod.rs
@@ -109,6 +109,17 @@ pub trait LayoutType: FlatLen + HasNameTree + Clone {
     fn builder(&self) -> Self::Builder;
 }
 
+/// A schematic hardware data struct.
+///
+/// Only intended for use by Substrate procedural macros.
+pub trait StructData {
+    /// Returns a list of the names of the fields in this struct.
+    fn fields(&self) -> Vec<ArcStr>;
+
+    /// Returns the list of nodes contained by the field of the given name.
+    fn field_nodes(&self, name: &str) -> Option<Vec<Node>>;
+}
+
 /// Schematic hardware data.
 ///
 /// An instance of a [`SchematicType`].

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -8,6 +8,8 @@ pub use codegen::*;
 pub use geometry;
 #[doc(inline)]
 pub use scir;
+#[doc(inline)]
+pub use spice;
 
 pub mod block;
 pub mod context;

--- a/tests/data/spice/buffer_commercial.spice
+++ b/tests/data/spice/buffer_commercial.spice
@@ -1,0 +1,11 @@
+* CMOS buffer
+
+.subckt buffer din dout vdd vss
+X0 din dinb vdd vss inverter
+X1 dinb dout vdd vss inverter
+.ends
+
+.subckt inverter din dout vdd vss
+X0 dout din vss vss nshort w=2 l=0.15
+X1 dout din vdd vdd pshort w=4 l=0.15
+.ends

--- a/tests/src/hard_macro.rs
+++ b/tests/src/hard_macro.rs
@@ -1,53 +1,47 @@
 use crate::shared::buffer::BufferIo;
-use arcstr::ArcStr;
 use serde::{Deserialize, Serialize};
-use sky130pdk::Sky130OpenPdk;
-use spice::parser::conv::ScirConverter;
-use std::collections::HashMap;
-use std::sync::Arc;
-use substrate::io::{Flatten, Node};
-use substrate::schematic::{HasSchematic, HasSchematicImpl, PrimitiveDevice};
+use sky130pdk::{Sky130CommercialPdk, Sky130OpenPdk};
 use substrate::Block;
+use substrate::HasSchematicImpl;
+use test_log::test;
 
-#[derive(Block, Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
-#[substrate(
-    io = "BufferIo",
-    // schematic(path = "/path/to/schematic", fmt = "spectre")
-)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, Block, HasSchematicImpl)]
+#[substrate(io = "BufferIo")]
+#[substrate(schematic(
+    source = "crate::paths::test_data(\"spice/buffer.spice\")",
+    name = "buffer",
+    fmt = "spice",
+    pdk = "Sky130OpenPdk"
+))]
+#[substrate(schematic(
+    source = "crate::paths::test_data(\"spice/buffer_commercial.spice\")",
+    name = "buffer",
+    fmt = "spice",
+    pdk = "Sky130CommercialPdk"
+))]
 pub struct BufferHardMacro;
 
-impl HasSchematic for BufferHardMacro {
-    type Data = ();
-}
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, Block, HasSchematicImpl)]
+#[substrate(io = "BufferIo")]
+#[substrate(schematic(
+    source = "r#\"
+        * CMOS buffer
 
-impl HasSchematicImpl<Sky130OpenPdk> for BufferHardMacro {
-    fn schematic(
-        &self,
-        io: &<<Self as substrate::block::Block>::Io as substrate::io::SchematicType>::Data,
-        cell: &mut substrate::schematic::CellBuilder<Sky130OpenPdk, Self>,
-    ) -> substrate::error::Result<Self::Data> {
-        let path = crate::paths::test_data("spice/buffer.spice");
-        let parsed = spice::parser::Parser::parse_file(path).unwrap();
-        let mut conv = ScirConverter::new("buffer", &parsed.ast);
-        conv.blackbox("sky130_fd_pr__nfet_01v8");
-        conv.blackbox("sky130_fd_pr__pfet_01v8");
-        let lib = Arc::new(conv.convert().unwrap());
-        let cell_id = lib.cell_id_named("buffer");
-        let connections: HashMap<ArcStr, Vec<Node>> = HashMap::from_iter([
-            ("din".into(), io.din.flatten_vec()),
-            ("dout".into(), io.dout.flatten_vec()),
-            ("vdd".into(), io.vdd.flatten_vec()),
-            ("vss".into(), io.vss.flatten_vec()),
-        ]);
-        cell.add_primitive(PrimitiveDevice::ScirInstance {
-            lib,
-            cell: cell_id,
-            name: "buffer_hard_macro_inner".into(),
-            connections,
-        });
-        Ok(())
-    }
-}
+        .subckt buffer din dout vdd vss
+        X0 din dinb vdd vss inverter
+        X1 dinb dout vdd vss inverter
+        .ends
+
+        .subckt inverter din dout vdd vss
+        X0 dout din vss vss sky130_fd_pr__nfet_01v8 w=2 l=0.15
+        X1 dout din vdd vdd sky130_fd_pr__pfet_01v8 w=4 l=0.15
+        .ends
+    \"#",
+    name = "buffer",
+    fmt = "inline-spice",
+    pdk = "Sky130OpenPdk"
+))]
+pub struct BufferInlineHardMacro;
 
 #[test]
 fn export_hard_macro() {
@@ -55,6 +49,42 @@ fn export_hard_macro() {
 
     let ctx = sky130_open_ctx();
     let lib = ctx.export_scir(BufferHardMacro);
+    assert_eq!(lib.scir.cells().count(), 3);
+
+    println!("SCIR Library:\n{:?}", lib.scir);
+
+    let mut buf: Vec<u8> = Vec::new();
+    let includes = Vec::new();
+    let netlister = spectre::netlist::Netlister::new(&lib.scir, &includes, &mut buf);
+    netlister.export().unwrap();
+    let string = String::from_utf8(buf).unwrap();
+    println!("Netlist:\n{}", string);
+}
+
+#[test]
+fn export_hard_macro_in_another_pdk() {
+    use crate::shared::pdk::sky130_commercial_ctx;
+
+    let ctx = sky130_commercial_ctx();
+    let lib = ctx.export_scir(BufferHardMacro);
+    assert_eq!(lib.scir.cells().count(), 3);
+
+    println!("SCIR Library:\n{:?}", lib.scir);
+
+    let mut buf: Vec<u8> = Vec::new();
+    let includes = Vec::new();
+    let netlister = spectre::netlist::Netlister::new(&lib.scir, &includes, &mut buf);
+    netlister.export().unwrap();
+    let string = String::from_utf8(buf).unwrap();
+    println!("Netlist:\n{}", string);
+}
+
+#[test]
+fn export_inline_hard_macro() {
+    use crate::shared::pdk::sky130_open_ctx;
+
+    let ctx = sky130_open_ctx();
+    let lib = ctx.export_scir(BufferInlineHardMacro);
     assert_eq!(lib.scir.cells().count(), 3);
 
     println!("SCIR Library:\n{:?}", lib.scir);


### PR DESCRIPTION
Implement codegen for hard macros.

Users can annotate a block with `#[derive(HasSchematicImpl)]` to
turn it into a hard macro. This derive macro can accept
a path to a SPICE netlist or an inline SPICE netlist.
We then generate a `HasSchematicImpl` implementation for the
PDK the user provides, using their provided source schematic.

Supporting Spectre netlists is a planned future feature.
