### PR TITLE
feat(codegen): implement derive proc macro for layout hard macros

### DIFF
--- a/codegen/src/block/layout.rs
+++ b/codegen/src/block/layout.rs
@@ -1,5 +1,5 @@
 use darling::ast::{Fields, Style};
-use darling::{ast, FromDeriveInput, FromMeta, FromField, FromVariant};
+use darling::{ast, FromDeriveInput, FromField, FromMeta, FromVariant};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use syn::parse_quote;

--- a/codegen/src/block/layout.rs
+++ b/codegen/src/block/layout.rs
@@ -1,5 +1,5 @@
 use darling::ast::{Fields, Style};
-use darling::{ast, FromDeriveInput, FromField, FromVariant};
+use darling::{ast, FromDeriveInput, FromMeta, FromField, FromVariant};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use syn::parse_quote;
@@ -233,6 +233,92 @@ impl ToTokens for DataInputReceiver {
                     }
                 }
             }
+        };
+
+        tokens.extend(quote! {
+            #expanded
+        });
+    }
+}
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(substrate), supports(any))]
+pub struct HasLayoutImplInputReceiver {
+    ident: syn::Ident,
+    generics: syn::Generics,
+    #[allow(unused)]
+    io: darling::util::Ignored,
+    #[darling(multiple)]
+    #[allow(unused)]
+    schematic: Vec<darling::util::Ignored>,
+    #[darling(multiple)]
+    layout: Vec<LayoutHardMacro>,
+}
+
+#[derive(Debug, FromMeta)]
+pub struct LayoutHardMacro {
+    source: syn::Expr,
+    fmt: darling::util::SpannedValue<String>,
+    pdk: syn::Type,
+    name: String,
+}
+
+impl ToTokens for HasLayoutImplInputReceiver {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let substrate = substrate_ident();
+        let HasLayoutImplInputReceiver {
+            ref ident,
+            ref generics,
+            ref layout,
+            ..
+        } = *self;
+
+        let (imp, ty, wher) = generics.split_for_impl();
+
+        let has_layout = quote! {
+            impl #imp #substrate::layout::HasLayout for #ident #ty #wher {
+                type Data = ();
+            }
+        };
+
+        let has_layout_impls = layout.iter().map(|layout| {
+            let LayoutHardMacro { source, fmt, pdk, name } = layout;
+
+            // The raw_cell token stream must create an Arc<RawCell>.
+            // The token stream has access to source.
+            let raw_cell = match fmt.as_str() {
+                "gds" => quote! {
+                    cell.ctx.read_gds_cell(source, #name)?
+                },
+                fmtstr => proc_macro_error::abort!(fmt.span(), "unsupported layout hard macro format: `{}`", fmtstr),
+            };
+
+            quote! {
+                impl #imp #substrate::layout::HasLayoutImpl<#pdk> for #ident #ty #wher {
+                    fn layout(
+                        &self,
+                        io: &mut <<Self as substrate::block::Block>::Io as substrate::io::LayoutType>::Builder,
+                        cell: &mut substrate::layout::CellBuilder<Sky130OpenPdk, Self>,
+                    ) -> substrate::error::Result<Self::Data> {
+
+                        let source = { #source };
+
+                        let raw_cell = { #raw_cell };
+
+                        #substrate::io::HierarchicalBuildFrom::<#substrate::layout::element::NamedPorts>::build_from_top(io, raw_cell.port_map());
+                        let inst = #substrate::layout::element::RawInstance::new(raw_cell, #substrate::geometry::point::Point::zero(), #substrate::geometry::orientation::Orientation::default());
+                        cell.draw(inst)?;
+
+                        Ok(())
+                    }
+                }
+            }
+        });
+
+        let expanded = quote! {
+            #has_layout
+
+            #(#has_layout_impls)*
         };
 
         tokens.extend(quote! {

--- a/codegen/src/block/layout.rs
+++ b/codegen/src/block/layout.rs
@@ -297,9 +297,9 @@ impl ToTokens for HasLayoutImplInputReceiver {
                 impl #imp #substrate::layout::HasLayoutImpl<#pdk> for #ident #ty #wher {
                     fn layout(
                         &self,
-                        io: &mut <<Self as substrate::block::Block>::Io as substrate::io::LayoutType>::Builder,
-                        cell: &mut substrate::layout::CellBuilder<Sky130OpenPdk, Self>,
-                    ) -> substrate::error::Result<Self::Data> {
+                        io: &mut <<Self as #substrate::block::Block>::Io as #substrate::io::LayoutType>::Builder,
+                        cell: &mut #substrate::layout::CellBuilder<#pdk, Self>,
+                    ) -> #substrate::error::Result<Self::Data> {
 
                         let source = { #source };
 

--- a/codegen/src/block/mod.rs
+++ b/codegen/src/block/mod.rs
@@ -17,6 +17,9 @@ pub struct BlockInputReceiver {
     #[darling(multiple)]
     #[allow(unused)]
     schematic: Vec<darling::util::Ignored>,
+    #[darling(multiple)]
+    #[allow(unused)]
+    layout: Vec<darling::util::Ignored>,
 }
 
 impl ToTokens for BlockInputReceiver {

--- a/codegen/src/block/schematic.rs
+++ b/codegen/src/block/schematic.rs
@@ -248,6 +248,9 @@ pub struct HasSchematicImplInputReceiver {
     #[allow(unused)]
     io: darling::util::Ignored,
     #[darling(multiple)]
+    #[allow(unused)]
+    layout: Vec<darling::util::Ignored>,
+    #[darling(multiple)]
     schematic: Vec<SchematicHardMacro>,
 }
 

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -424,6 +424,52 @@ pub fn derive_has_schematic_impl(input: TokenStream) -> TokenStream {
     .into()
 }
 
+/// Derives `substrate::layout::HasLayoutImpl` for any Substrate block.
+///
+/// This turns the block into a layout hard macro.
+/// You must add a `#[substrate(layout(...))]` attribute to configure this macro;
+/// see the examples below.
+/// Using multiple `#[substrate(layout(...))]` attributes allows you to
+/// generate `HasLayoutImpl` implementations for multiple PDKs.
+///
+/// This macro only works on Substrate blocks,
+/// so you must also add a `#[derive(Block)]` attribute
+/// or implement `Block` manually.
+///
+/// # Arguments
+///
+/// This macro requires the following arguments (see [Supported formats](#supported-formats) for more details):
+/// * `source`: The source from which to read the contents of this block's layout.
+/// * `name`: The name of the block's contents in `source`. For example, if
+///   source is a GDS library file, name should be set to the name of the desired
+///   cell in that file.
+/// * `fmt`: The layout source format.
+/// * `pdk`: The PDK to which source corresponds.
+///
+/// # Supported formats
+///
+/// The following formats are supported:
+///
+/// * `gds`: Source should be an expression that evaluates to the file path of a GDSII library.
+///
+/// Note that expressions can be arbitrary Rust expressions. Here are some examples:
+/// * `fmt = "\"/path/to/layout.gds\""` (note that you need the escaped quotes to make this a
+/// string literal).
+/// * `fmt = "function_that_returns_path()"`
+/// * `fmt = "function_with_arguments_that_returns_path(\"my_argument\")"`
+#[proc_macro_error]
+#[proc_macro_derive(HasLayoutImpl, attributes(substrate))]
+pub fn derive_has_layout_impl(input: TokenStream) -> TokenStream {
+    let receiver = block::layout::HasLayoutImplInputReceiver::from_derive_input(
+        &parse_macro_input!(input as DeriveInput),
+    );
+    let receiver = handle_error!(receiver);
+    quote!(
+        #receiver
+    )
+    .into()
+}
+
 pub(crate) fn substrate_ident() -> TokenStream2 {
     match crate_name("substrate").expect("substrate is present in `Cargo.toml`") {
         FoundCrate::Itself => quote!(::substrate),

--- a/substrate/src/context.rs
+++ b/substrate/src/context.rs
@@ -227,7 +227,7 @@ impl<PDK: Pdk> Context<PDK> {
                 let ports = HashMap::from_iter(
                     block
                         .io()
-                        .flat_names(arcstr::literal!("io"))
+                        .flat_names(None)
                         .into_iter()
                         .zip(io.flatten_vec().into_iter()),
                 );
@@ -462,7 +462,7 @@ fn prepare_cell_builder<PDK: Pdk, T: Block>(
     assert!(nodes_rest.is_empty());
     let cell_name = block.name();
 
-    let names = io.flat_names(arcstr::literal!("io"));
+    let names = io.flat_names(None);
     let dirs = io.flatten_vec();
     assert_eq!(nodes.len(), names.len());
     assert_eq!(nodes.len(), dirs.len());

--- a/substrate/src/io/impls.rs
+++ b/substrate/src/io/impls.rs
@@ -260,7 +260,7 @@ impl Undirected for IoShape {}
 
 impl HierarchicalBuildFrom<NamedPorts> for OptionBuilder<IoShape> {
     fn build_from(&mut self, path: &mut NameBuf, source: &NamedPorts) {
-        self.set(source.get(&path).unwrap().primary.clone());
+        self.set(source.get(path).unwrap().primary.clone());
     }
 }
 
@@ -347,7 +347,7 @@ impl Undirected for PortGeometryBuilder {}
 
 impl HierarchicalBuildFrom<NamedPorts> for PortGeometryBuilder {
     fn build_from(&mut self, path: &mut NameBuf, source: &NamedPorts) {
-        let source = source.get(&path).unwrap();
+        let source = source.get(path).unwrap();
         self.primary = Some(source.primary.clone());
         self.unnamed_shapes.clone_from(&source.unnamed_shapes);
         self.named_shapes.clone_from(&source.named_shapes);
@@ -739,7 +739,9 @@ impl<T: HasNameTree> HasNameTree for Array<T> {
 }
 
 impl<T, S> HierarchicalBuildFrom<S> for ArrayData<T>
-where T: HierarchicalBuildFrom<S> {
+where
+    T: HierarchicalBuildFrom<S>,
+{
     fn build_from(&mut self, path: &mut NameBuf, source: &S) {
         for (i, elem) in self.elems.iter_mut().enumerate() {
             path.push(i);
@@ -974,7 +976,10 @@ impl NameTree {
     }
 
     /// Create a new name tree rooted at the given **optional** name fragment.
-    pub fn with_optional_fragment(fragment: Option<impl Into<NameFragment>>, children: Vec<NameTree>) -> Self {
+    pub fn with_optional_fragment(
+        fragment: Option<impl Into<NameFragment>>,
+        children: Vec<NameTree>,
+    ) -> Self {
         Self {
             fragment: fragment.map(|f| f.into()),
             children,
@@ -1082,10 +1087,7 @@ mod tests {
             vec![
                 NameTree::new(
                     "pwr",
-                    vec![
-                        NameTree::new("vdd", vec![]),
-                        NameTree::new("vss", vec![]),
-                    ],
+                    vec![NameTree::new("vdd", vec![]), NameTree::new("vss", vec![])],
                 ),
                 NameTree::new("out", vec![]),
             ],
@@ -1118,18 +1120,13 @@ mod tests {
 
     #[test]
     fn flatten_name_tree_with_empty_root() {
-        let tree = NameTree::with_empty_fragment(
-            vec![
-                NameTree::new(
-                    "pwr",
-                    vec![
-                        NameTree::new("vdd", vec![]),
-                        NameTree::new("vss", vec![]),
-                    ],
-                ),
-                NameTree::new("out", vec![]),
-            ],
-        );
+        let tree = NameTree::with_empty_fragment(vec![
+            NameTree::new(
+                "pwr",
+                vec![NameTree::new("vdd", vec![]), NameTree::new("vss", vec![])],
+            ),
+            NameTree::new("out", vec![]),
+        ]);
 
         assert_eq!(
             tree.flatten(),

--- a/substrate/src/io/mod.rs
+++ b/substrate/src/io/mod.rs
@@ -147,14 +147,19 @@ pub trait CustomLayoutType<T: LayoutType>: LayoutType {
     fn from_layout_type(other: &T) -> Self;
 }
 
+/// Construct an instance of `Self` hierarchically given a name buffer and a source of type `T`.
 pub trait HierarchicalBuildFrom<T> {
+    /// Build `self` from the given root path and source.
     fn build_from(&mut self, path: &mut NameBuf, source: &T);
 
+    /// Build `self` from the given source, starting with an empty top-level name buffer.
     fn build_from_top(&mut self, source: &T) {
         let mut buf = NameBuf::new();
         self.build_from(&mut buf, source);
     }
 
+    /// Build `self` from the given source, starting with a top-level name buffer containing the
+    /// given name fragment.
     fn build_from_top_prefix(&mut self, prefix: impl Into<NameFragment>, source: &T) {
         let mut buf = NameBuf::new();
         buf.push(prefix);

--- a/substrate/src/layout/element.rs
+++ b/substrate/src/layout/element.rs
@@ -33,6 +33,9 @@ impl CellId {
     }
 }
 
+/// A mapping from names to ports.
+pub type NamedPorts = HashMap<NameBuf, PortGeometry>;
+
 /// A raw layout cell.
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct RawCell {
@@ -40,7 +43,7 @@ pub struct RawCell {
     pub(crate) name: ArcStr,
     pub(crate) elements: Vec<Element>,
     pub(crate) blockages: Vec<Shape>,
-    ports: HashMap<NameBuf, PortGeometry>,
+    ports: NamedPorts,
     port_names: HashMap<String, NameBuf>,
 }
 
@@ -65,7 +68,8 @@ impl RawCell {
         }
     }
 
-    pub(crate) fn port_map(&self) -> &HashMap<NameBuf, PortGeometry> {
+    #[doc(hidden)]
+    pub fn port_map(&self) -> &NamedPorts {
         &self.ports
     }
 

--- a/substrate/src/layout/mod.rs
+++ b/substrate/src/layout/mod.rs
@@ -40,7 +40,7 @@ use geometry::{
     },
 };
 
-use crate::io::{LayoutType, NameBuf, NameFragment};
+use crate::io::LayoutType;
 use crate::pdk::Pdk;
 use crate::{block::Block, error::Error};
 use crate::{context::Context, error::Result};
@@ -548,4 +548,3 @@ impl<E: Into<Element>, PDK: Pdk> Draw<PDK> for E {
         Ok(())
     }
 }
-

--- a/substrate/src/layout/mod.rs
+++ b/substrate/src/layout/mod.rs
@@ -40,7 +40,7 @@ use geometry::{
     },
 };
 
-use crate::io::LayoutType;
+use crate::io::{LayoutType, NameBuf, NameFragment};
 use crate::pdk::Pdk;
 use crate::{block::Block, error::Error};
 use crate::{context::Context, error::Result};
@@ -549,17 +549,3 @@ impl<E: Into<Element>, PDK: Pdk> Draw<PDK> for E {
     }
 }
 
-/// Indicates that a layout port or port builder can be constructed from a reference to `T`.
-pub trait BuildFrom<T> {
-    /// Mutates `self`, taking data from `source`.
-    fn build_from(&mut self, source: &T);
-}
-
-impl<T> BuildFrom<T> for T
-where
-    T: Clone,
-{
-    fn build_from(&mut self, source: &T) {
-        self.clone_from(source);
-    }
-}

--- a/substrate/src/schematic/mod.rs
+++ b/substrate/src/schematic/mod.rs
@@ -114,7 +114,7 @@ impl<PDK: Pdk, T: Block> CellBuilder<PDK, T> {
         assert!(ids_rest.is_empty());
 
         let nodes = data.flatten_vec();
-        let names = ty.flat_names(name.into());
+        let names = ty.flat_names(Some(name.into().into()));
         assert_eq!(nodes.len(), names.len());
 
         self.node_names.extend(nodes.iter().copied().zip(names));
@@ -204,7 +204,9 @@ impl<PDK: Pdk, T: Block> CellBuilder<PDK, T> {
         assert!(ids_rest.is_empty());
 
         let connections = io_data.flatten_vec();
-        let names = io.flat_names(arcstr::format!("xinst{}", self.instances.len()));
+        let names = io.flat_names(Some(
+            arcstr::format!("xinst{}", self.instances.len()).into(),
+        ));
         assert_eq!(connections.len(), names.len());
 
         self.node_names

--- a/tests/src/derive/io.rs
+++ b/tests/src/derive/io.rs
@@ -1,8 +1,10 @@
 //! Tests for ensuring that `#[derive(Io)]` works.
 
-use substrate::io::{Input, LayoutType, Output, SchematicType, Signal, Undirected, HierarchicalBuildFrom};
-use substrate::Io;
+use substrate::io::{
+    HierarchicalBuildFrom, Input, LayoutType, Output, SchematicType, Signal, Undirected,
+};
 use substrate::layout::element::NamedPorts;
+use substrate::Io;
 
 /// An Io with a generic type parameter.
 #[derive(Debug, Clone, Io)]

--- a/tests/src/derive/io.rs
+++ b/tests/src/derive/io.rs
@@ -1,7 +1,8 @@
 //! Tests for ensuring that `#[derive(Io)]` works.
 
-use substrate::io::{Input, LayoutType, Output, SchematicType, Signal, Undirected};
+use substrate::io::{Input, LayoutType, Output, SchematicType, Signal, Undirected, HierarchicalBuildFrom};
 use substrate::Io;
+use substrate::layout::element::NamedPorts;
 
 /// An Io with a generic type parameter.
 #[derive(Debug, Clone, Io)]
@@ -10,7 +11,7 @@ where
     T: Clone + Undirected + SchematicType + LayoutType + 'static,
     <T as SchematicType>::Data: Undirected,
     <T as LayoutType>::Data: Undirected,
-    <T as LayoutType>::Builder: Undirected,
+    <T as LayoutType>::Builder: Undirected + HierarchicalBuildFrom<NamedPorts>,
 {
     /// A single input field.
     pub signal: Input<T>,

--- a/tests/src/gds.rs
+++ b/tests/src/gds.rs
@@ -162,13 +162,13 @@ fn test_gds_reexport() {
     assert_eq!(b_elems.len(), 0, "expected no elements in cell B");
     assert_eq!(b_annotations.len(), 0, "expected 0 annotations in cell B");
     assert_eq!(b.ports().count(), 4);
-    assert!(b.port_named("io_vdd").is_some());
-    assert!(b.port_named("io_vss").is_some());
-    assert!(b.port_named("io_din").is_some());
-    assert!(b.port_named("io_dout").is_some());
+    assert!(b.port_named("vdd").is_some());
+    assert!(b.port_named("vss").is_some());
+    assert!(b.port_named("din").is_some());
+    assert!(b.port_named("dout").is_some());
 
     let r = b
-        .port_named("io_vdd")
+        .port_named("vdd")
         .unwrap()
         .primary
         .shape()

--- a/tests/src/gds.rs
+++ b/tests/src/gds.rs
@@ -167,13 +167,7 @@ fn test_gds_reexport() {
     assert!(b.port_named("din").is_some());
     assert!(b.port_named("dout").is_some());
 
-    let r = b
-        .port_named("vdd")
-        .unwrap()
-        .primary
-        .shape()
-        .rect()
-        .unwrap();
+    let r = b.port_named("vdd").unwrap().primary.shape().rect().unwrap();
     assert_eq!(r.width(), 50);
     assert_eq!(r.height(), 25);
 

--- a/tests/src/hard_macro.rs
+++ b/tests/src/hard_macro.rs
@@ -1,15 +1,24 @@
-use crate::shared::buffer::{BufferIo, BufferIoLayoutBuilder};
-use geometry::prelude::{Orientation, Point};
+use crate::shared::buffer::BufferIo;
+
 use serde::{Deserialize, Serialize};
 use sky130pdk::{Sky130CommercialPdk, Sky130OpenPdk};
-use substrate::io::HierarchicalBuildFrom;
-use substrate::layout::element::{NamedPorts, RawInstance};
-use substrate::layout::{HasLayout, HasLayoutImpl};
+
 use substrate::Block;
-use substrate::{HasSchematicImpl, HasLayoutImpl};
+use substrate::{HasLayoutImpl, HasSchematicImpl};
 use test_log::test;
 
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, Block, HasSchematicImpl, HasLayoutImpl)]
+#[derive(
+    Clone,
+    Debug,
+    Hash,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Block,
+    HasSchematicImpl,
+    HasLayoutImpl,
+)]
 #[substrate(io = "BufferIo")]
 #[substrate(schematic(
     source = "crate::paths::test_data(\"spice/buffer.spice\")",

--- a/tests/src/schematic.rs
+++ b/tests/src/schematic.rs
@@ -39,9 +39,9 @@ fn can_generate_vdivider_schematic() {
         .map(|p| vdiv.signal(p.signal()).name.clone())
         .collect();
     assert_eq!(port_names.len(), 3);
-    assert!(port_names.contains("io_pwr_vdd"));
-    assert!(port_names.contains("io_pwr_vss"));
-    assert!(port_names.contains("io_out"));
+    assert!(port_names.contains("pwr_vdd"));
+    assert!(port_names.contains("pwr_vss"));
+    assert!(port_names.contains("out"));
     assert_eq!(vdiv.ports().count(), 3);
     let contents = vdiv.contents().as_ref().unwrap_clear();
     assert_eq!(contents.primitives().count(), 0);
@@ -98,10 +98,10 @@ fn internal_signal_names_preserved() {
     let vdiv = scir.cell_named("buffer_5");
     let sigs: HashSet<ArcStr> = vdiv.signals().map(|p| p.1.name.clone()).collect();
     assert_eq!(sigs.len(), 5);
-    assert!(sigs.contains("io_vdd"));
-    assert!(sigs.contains("io_vss"));
-    assert!(sigs.contains("io_din"));
-    assert!(sigs.contains("io_dout"));
+    assert!(sigs.contains("vdd"));
+    assert!(sigs.contains("vss"));
+    assert!(sigs.contains("din"));
+    assert!(sigs.contains("dout"));
     assert!(sigs.contains("x"));
 }
 

--- a/tests/src/shared/vdivider/mod.rs
+++ b/tests/src/shared/vdivider/mod.rs
@@ -87,7 +87,7 @@ impl Block for Vdivider {
 }
 
 #[derive(Debug, Clone, Io)]
-struct VdividerArrayIo {
+pub struct VdividerArrayIo {
     pub elements: Array<PowerIo>,
 }
 

--- a/tests/src/shared/vdivider/tb.rs
+++ b/tests/src/shared/vdivider/tb.rs
@@ -123,8 +123,8 @@ impl<PDK: Pdk> HasTestbenchSchematicImpl<PDK, Spectre> for VdividerArrayTb {
         });
 
         for i in 0..3 {
-            cell.connect(dut.io()[i].vdd, vdd);
-            cell.connect(dut.io()[i].vss, io.vss);
+            cell.connect(dut.io().elements[i].vdd, vdd);
+            cell.connect(dut.io().elements[i].vss, io.vss);
         }
 
         let vsource = cell.instantiate_tb(Vsource::dc(dec!(1.8)));
@@ -183,7 +183,7 @@ impl<PDK: Pdk> Testbench<PDK, Spectre> for VdividerArrayTb {
             .collect();
 
         let vdd = output
-            .get_data(&cell.data().cell().io()[0].vdd)
+            .get_data(&cell.data().cell().io().elements[0].vdd)
             .unwrap()
             .clone();
 

--- a/tools/spectre/src/blocks.rs
+++ b/tools/spectre/src/blocks.rs
@@ -79,12 +79,12 @@ impl<PDK: Pdk> HasTestbenchSchematicImpl<PDK, Spectre> for Vsource {
     ) -> substrate::error::Result<Self::Data> {
         use std::fmt::Write;
         let contents = match self {
-            Self::Dc(dc) => format!("V0 ( io_p io_n ) vsource type=dc dc={}", dc),
+            Self::Dc(dc) => format!("V0 ( p n ) vsource type=dc dc={}", dc),
             Self::Pulse(pulse) => {
                 let mut s = String::new();
                 write!(
                     &mut s,
-                    "V0 ( io_p io_n ) vsource type=pulse val0={} val1={}",
+                    "V0 ( p n ) vsource type=pulse val0={} val1={}",
                     pulse.val0, pulse.val1
                 )
                 .unwrap();


### PR DESCRIPTION
Implement a `#[derive(HasLayoutImpl)]` procedural macro for
turning Substrate blocks into layout hard macros.

Also remove `io_` node name prefixing.

feat(io): remove io prefix from elements of IOs