### PR TITLE
fix(tests): remove hardcoded resistor value

### DIFF
--- a/tests/src/schematic.rs
+++ b/tests/src/schematic.rs
@@ -22,8 +22,8 @@ use crate::shared::{buffer::BufferNxM, pdk::ExamplePdkB};
 fn can_generate_vdivider_schematic() {
     let ctx = Context::new(ExamplePdkA);
     let vdivider = Vdivider {
-        r1: Resistor { r: 300 },
-        r2: Resistor { r: 100 },
+        r1: Resistor::new(300),
+        r2: Resistor::new(100),
     };
     let RawLib { scir, conv: _ } = ctx.export_scir(vdivider);
     assert_eq!(scir.cells().count(), 3);

--- a/tests/src/shared/vdivider/mod.rs
+++ b/tests/src/shared/vdivider/mod.rs
@@ -1,5 +1,5 @@
 use arcstr::ArcStr;
-use rust_decimal_macros::dec;
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use substrate::block::Block;
 use substrate::io::{Array, InOut, Output, Signal};
@@ -31,7 +31,16 @@ pub struct VdividerIo {
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Resistor {
-    pub r: usize,
+    pub value: Decimal,
+}
+
+impl Resistor {
+    #[inline]
+    pub fn new(value: impl Into<Decimal>) -> Self {
+        Self {
+            value: value.into(),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
@@ -41,10 +50,11 @@ pub struct Vdivider {
 }
 
 impl Vdivider {
-    fn new(r1: usize, r2: usize) -> Self {
+    #[inline]
+    fn new(r1: impl Into<Decimal>, r2: impl Into<Decimal>) -> Self {
         Self {
-            r1: Resistor { r: r1 },
-            r2: Resistor { r: r2 },
+            r1: Resistor::new(r1),
+            r2: Resistor::new(r2),
         }
     }
 }
@@ -62,7 +72,7 @@ impl Block for Resistor {
     }
 
     fn name(&self) -> ArcStr {
-        arcstr::format!("resistor_{}", self.r)
+        arcstr::format!("resistor_{}", self.value)
     }
 
     fn io(&self) -> Self::Io {
@@ -78,7 +88,7 @@ impl Block for Vdivider {
     }
 
     fn name(&self) -> ArcStr {
-        arcstr::format!("vdivider_{}_{}", self.r1.r, self.r2.r)
+        arcstr::format!("vdivider_{}_{}", self.r1.value, self.r2.value)
     }
 
     fn io(&self) -> Self::Io {
@@ -138,7 +148,7 @@ impl<PDK: Pdk> HasSchematicImpl<PDK> for Resistor {
         cell.add_primitive(PrimitiveDevice::Res2 {
             pos: *io.p,
             neg: *io.n,
-            value: dec!(1000),
+            value: self.value,
         });
         Ok(())
     }

--- a/tests/src/shared/vdivider/tb.rs
+++ b/tests/src/shared/vdivider/tb.rs
@@ -164,7 +164,7 @@ impl<PDK: Pdk> Testbench<PDK, Spectre> for VdividerArrayTb {
             .data()
             .into_iter()
             .map(|inst| {
-                (inst.block().r1.value / (inst.block().r1.value + inst.block().r2.value))
+                (inst.block().r2.value / (inst.block().r1.value + inst.block().r2.value))
                     .to_f64()
                     .unwrap()
                     * 1.8f64

--- a/tests/src/shared/vdivider/tb.rs
+++ b/tests/src/shared/vdivider/tb.rs
@@ -1,3 +1,4 @@
+use rust_decimal::prelude::ToPrimitive;
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use spectre::blocks::Vsource;
@@ -41,8 +42,8 @@ impl<PDK: Pdk> HasTestbenchSchematicImpl<PDK, Spectre> for VdividerTb {
         let vdd = cell.signal("vdd", Signal);
         let out = cell.signal("out", Signal);
         let dut = cell.instantiate(Vdivider {
-            r1: Resistor { r: 20 },
-            r2: Resistor { r: 20 },
+            r1: Resistor::new(20),
+            r2: Resistor::new(20),
         });
 
         cell.connect(dut.io().pwr.vdd, vdd);
@@ -164,7 +165,10 @@ impl<PDK: Pdk> Testbench<PDK, Spectre> for VdividerArrayTb {
             .data()
             .into_iter()
             .map(|inst| {
-                inst.block().r1.r as f64 / (inst.block().r1.r + inst.block().r2.r) as f64 * 1.8
+                (inst.block().r1.value / (inst.block().r1.value + inst.block().r2.value))
+                    .to_f64()
+                    .unwrap()
+                    * 1.8f64
             })
             .collect();
 

--- a/tests/src/shared/vdivider/tb.rs
+++ b/tests/src/shared/vdivider/tb.rs
@@ -114,12 +114,11 @@ impl<PDK: Pdk> HasTestbenchSchematicImpl<PDK, Spectre> for VdividerArrayTb {
         cell: &mut substrate::schematic::TestbenchCellBuilder<PDK, Spectre, Self>,
     ) -> substrate::error::Result<Self::Data> {
         let vdd = cell.signal("vdd", Signal);
-        // TODO: Use other resistor sizings once primitive parametrization is implemented.
         let dut = cell.instantiate(VdividerArray {
             vdividers: vec![
                 Vdivider::new(300, 300),
-                Vdivider::new(600, 600),
-                Vdivider::new(800, 800),
+                Vdivider::new(600, 800),
+                Vdivider::new(3600, 1600),
             ],
         });
 


### PR DESCRIPTION
Also change the tests' `Resistor` component
to have a `Decimal` value, rather than a `usize` value.

fix(tests): use correct vdivider formula in tests

Previously it was top / sum. Now changed to bot / sum.