### PR TITLE
feat(layout): rename `HasLayout` and `HasLayoutImpl`

### DIFF
--- a/codegen/src/block/layout.rs
+++ b/codegen/src/block/layout.rs
@@ -243,7 +243,7 @@ impl ToTokens for DataInputReceiver {
 
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(substrate), supports(any))]
-pub struct HasLayoutImplInputReceiver {
+pub struct HasLayoutInputReceiver {
     ident: syn::Ident,
     generics: syn::Generics,
     #[allow(unused)]
@@ -266,10 +266,10 @@ pub struct LayoutHardMacro {
     name: String,
 }
 
-impl ToTokens for HasLayoutImplInputReceiver {
+impl ToTokens for HasLayoutInputReceiver {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let substrate = substrate_ident();
-        let HasLayoutImplInputReceiver {
+        let HasLayoutInputReceiver {
             ref ident,
             ref generics,
             ref layout,
@@ -279,7 +279,7 @@ impl ToTokens for HasLayoutImplInputReceiver {
         let (imp, ty, wher) = generics.split_for_impl();
 
         let has_layout = quote! {
-            impl #imp #substrate::layout::HasLayout for #ident #ty #wher {
+            impl #imp #substrate::layout::HasLayoutData for #ident #ty #wher {
                 type Data = ();
             }
         };
@@ -297,7 +297,7 @@ impl ToTokens for HasLayoutImplInputReceiver {
             };
 
             quote! {
-                impl #imp #substrate::layout::HasLayoutImpl<#pdk> for #ident #ty #wher {
+                impl #imp #substrate::layout::HasLayout<#pdk> for #ident #ty #wher {
                     fn layout(
                         &self,
                         io: &mut <<Self as #substrate::block::Block>::Io as #substrate::io::LayoutType>::Builder,

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -382,13 +382,13 @@ pub fn derive_has_schematic_impl(input: TokenStream) -> TokenStream {
     .into()
 }
 
-/// Derives `substrate::layout::HasLayoutImpl` for any Substrate block.
+/// Derives `substrate::layout::HasLayout` for any Substrate block.
 ///
 /// This turns the block into a layout hard macro.
 /// You must add a `#[substrate(layout(...))]` attribute to configure this macro;
 /// see the examples below.
 /// Using multiple `#[substrate(layout(...))]` attributes allows you to
-/// generate `HasLayoutImpl` implementations for multiple PDKs.
+/// generate `HasLayout` implementations for multiple PDKs.
 ///
 /// This macro only works on Substrate blocks,
 /// so you must also add a `#[derive(Block)]` attribute
@@ -416,11 +416,11 @@ pub fn derive_has_schematic_impl(input: TokenStream) -> TokenStream {
 /// * `fmt = "function_that_returns_path()"`
 /// * `fmt = "function_with_arguments_that_returns_path(\"my_argument\")"`
 #[proc_macro_error]
-#[proc_macro_derive(HasLayoutImpl, attributes(substrate))]
+#[proc_macro_derive(HasLayout, attributes(substrate))]
 pub fn derive_has_layout_impl(input: TokenStream) -> TokenStream {
-    let receiver = block::layout::HasLayoutImplInputReceiver::from_derive_input(
-        &parse_macro_input!(input as DeriveInput),
-    );
+    let receiver = block::layout::HasLayoutInputReceiver::from_derive_input(&parse_macro_input!(
+        input as DeriveInput
+    ));
     let receiver = handle_error!(receiver);
     quote!(
         #receiver

--- a/docs/examples/examples/core.rs
+++ b/docs/examples/examples/core.rs
@@ -7,7 +7,7 @@ use substrate::io::{
     CustomLayoutType, InOut, Input, IoShape, LayoutPort, Node, Output, PortGeometry, ShapePort,
     Signal,
 };
-use substrate::layout::{element::Shape, Cell, HasLayout, HasLayoutImpl, Instance};
+use substrate::layout::{element::Shape, Cell, HasLayout, HasLayoutData, Instance};
 use substrate::pdk::{Pdk, PdkLayers};
 use substrate::type_dispatch::impl_dispatch;
 use substrate::{
@@ -198,11 +198,11 @@ impl Block for Inverter {
 // end-code-snippet inverter
 
 // begin-code-snippet inverter_layout
-impl HasLayout for Inverter {
+impl HasLayoutData for Inverter {
     type Data = ();
 }
 
-impl HasLayoutImpl<ExamplePdk> for Inverter {
+impl HasLayout<ExamplePdk> for Inverter {
     fn layout(
         &self,
         io: &mut <<Self as substrate::block::Block>::Io as substrate::io::LayoutType>::Builder,
@@ -234,7 +234,7 @@ impl HasLayoutImpl<ExamplePdk> for Inverter {
 // end-code-snippet inverter_layout
 
 // begin-code-snippet inverter_multiprocess
-impl HasLayoutImpl<ExamplePdkA> for Inverter {
+impl HasLayout<ExamplePdkA> for Inverter {
     // begin-ellipses inverter_multiprocess
     fn layout(
         &self,
@@ -266,7 +266,7 @@ impl HasLayoutImpl<ExamplePdkA> for Inverter {
     // end-ellipses inverter_multiprocess
 }
 
-impl HasLayoutImpl<ExamplePdkB> for Inverter {
+impl HasLayout<ExamplePdkB> for Inverter {
     // begin-ellipses inverter_multiprocess
     fn layout(
         &self,
@@ -416,12 +416,12 @@ pub struct BufferData {
 }
 
 // begin-code-snippet buffer_layout
-impl HasLayout for Buffer {
+impl HasLayoutData for Buffer {
     type Data = BufferData;
 }
 
 // begin-code-snippet cell_builder_generate
-impl HasLayoutImpl<ExamplePdk> for Buffer {
+impl HasLayout<ExamplePdk> for Buffer {
     fn layout(
         // begin-ellipses cell_builder_generate
         &self,
@@ -450,7 +450,7 @@ impl HasLayoutImpl<ExamplePdk> for Buffer {
 
 // begin-code-snippet buffer_multiprocess
 #[impl_dispatch({ExamplePdkA; ExamplePdkB})]
-impl<PDK> HasLayoutImpl<PDK> for Buffer {
+impl<PDK> HasLayout<PDK> for Buffer {
     fn layout(
         &self,
         io: &mut <<Self as substrate::block::Block>::Io as substrate::io::LayoutType>::Builder,

--- a/substrate/src/context.rs
+++ b/substrate/src/context.rs
@@ -23,7 +23,7 @@ use crate::layout::element::RawCell;
 use crate::layout::error::{GdsExportError, LayoutError};
 use crate::layout::gds::{GdsExporter, GdsImporter, ImportedGds};
 use crate::layout::CellBuilder as LayoutCellBuilder;
-use crate::layout::HasLayoutImpl;
+use crate::layout::HasLayout;
 use crate::layout::LayoutContext;
 use crate::layout::{Cell as LayoutCell, CellHandle as LayoutCellHandle};
 use crate::pdk::layers::GdsLayerSpec;
@@ -176,7 +176,7 @@ impl<PDK: Pdk> Context<PDK> {
     /// Generates a layout for `block` in the background.
     ///
     /// Returns a handle to the cell being generated.
-    pub fn generate_layout<T: HasLayoutImpl<PDK>>(&self, block: T) -> LayoutCellHandle<T> {
+    pub fn generate_layout<T: HasLayout<PDK>>(&self, block: T) -> LayoutCellHandle<T> {
         let context_clone = self.clone();
         let mut inner_mut = self.inner.write().unwrap();
         let id = inner_mut.layout.get_id();
@@ -217,11 +217,7 @@ impl<PDK: Pdk> Context<PDK> {
     }
 
     /// Writes a layout to a GDS file.
-    pub fn write_layout<T: HasLayoutImpl<PDK>>(
-        &self,
-        block: T,
-        path: impl AsRef<Path>,
-    ) -> Result<()> {
+    pub fn write_layout<T: HasLayout<PDK>>(&self, block: T, path: impl AsRef<Path>) -> Result<()> {
         let handle = self.generate_layout(block);
         let cell = handle.try_cell()?;
 

--- a/substrate/src/layout/element.rs
+++ b/substrate/src/layout/element.rs
@@ -21,7 +21,7 @@ use crate::{
     pdk::{layers::LayerId, Pdk},
 };
 
-use super::{Draw, DrawReceiver, HasLayout, Instance};
+use super::{Draw, DrawReceiver, HasLayoutData, Instance};
 
 /// A context-wide unique identifier for a cell.
 #[derive(
@@ -205,7 +205,7 @@ impl Bbox for RawInstance {
     }
 }
 
-impl<T: HasLayout> TryFrom<Instance<T>> for RawInstance {
+impl<T: HasLayoutData> TryFrom<Instance<T>> for RawInstance {
     type Error = Error;
 
     fn try_from(value: Instance<T>) -> Result<Self> {

--- a/tests/src/derive/layout_data.rs
+++ b/tests/src/derive/layout_data.rs
@@ -1,15 +1,15 @@
-use substrate::layout::{HasLayout, Instance};
+use substrate::layout::{HasLayoutData, Instance};
 use substrate::LayoutData;
 
 #[derive(Default, LayoutData)]
-pub struct LayoutInstances<T: HasLayout> {
+pub struct LayoutInstances<T: HasLayoutData> {
     #[substrate(transform)]
     pub instances: Vec<Instance<T>>,
     pub field: i64,
 }
 
 #[derive(LayoutData)]
-pub enum EnumInstances<T: HasLayout> {
+pub enum EnumInstances<T: HasLayoutData> {
     One {
         #[substrate(transform)]
         one: Instance<T>,
@@ -23,7 +23,7 @@ pub enum EnumInstances<T: HasLayout> {
 }
 
 #[derive(LayoutData)]
-pub struct TwoInstances<T: HasLayout>(
+pub struct TwoInstances<T: HasLayoutData>(
     #[substrate(transform)] pub Instance<T>,
     #[substrate(transform)] pub Instance<T>,
     pub i64,

--- a/tests/src/hard_macro.rs
+++ b/tests/src/hard_macro.rs
@@ -4,11 +4,11 @@ use serde::{Deserialize, Serialize};
 use sky130pdk::Sky130OpenPdk;
 
 use substrate::Block;
-use substrate::{HasLayoutImpl, HasSchematic};
+use substrate::{HasLayout, HasSchematic};
 use test_log::test;
 
 #[derive(
-    Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, Block, HasSchematic, HasLayoutImpl,
+    Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, Block, HasSchematic, HasLayout,
 )]
 #[substrate(io = "BufferIo", flatten)]
 #[substrate(schematic(

--- a/tests/src/layout.rs
+++ b/tests/src/layout.rs
@@ -6,7 +6,7 @@ use substrate::context::Context;
 use substrate::geometry::transform::{Transform, Translate};
 use substrate::layout::element::Shape;
 use substrate::layout::tiling::{GridTile, GridTiler, Tile};
-use substrate::layout::{HasLayout, HasLayoutImpl, Instance};
+use substrate::layout::{HasLayout, HasLayoutData, Instance};
 use substrate::Block;
 use substrate::{LayoutData, TransformMut, TranslateMut};
 
@@ -36,11 +36,11 @@ pub enum PointEnum {
 #[substrate(io = "()")]
 pub struct GridTilerExample;
 
-impl HasLayout for GridTilerExample {
+impl HasLayoutData for GridTilerExample {
     type Data = ();
 }
 
-impl HasLayoutImpl<ExamplePdkA> for GridTilerExample {
+impl HasLayout<ExamplePdkA> for GridTilerExample {
     fn layout(
         &self,
         _io: &mut <<Self as substrate::block::Block>::Io as substrate::io::LayoutType>::Builder,

--- a/tests/src/shared/buffer/layout.rs
+++ b/tests/src/shared/buffer/layout.rs
@@ -11,7 +11,7 @@ use substrate::{
     layout::{
         element::Shape,
         tiling::{ArrayTiler, Tile, TileAlignMode},
-        HasLayout, HasLayoutImpl, Instance,
+        HasLayout, HasLayoutData, Instance,
     },
     pdk::{layers::HasPin, PdkLayers},
     DerivedLayerFamily, DerivedLayers, Layers, LayoutData,
@@ -21,11 +21,11 @@ use crate::shared::pdk::{ExamplePdkA, ExamplePdkB};
 
 use super::{Buffer, BufferN, BufferNxM, Inverter};
 
-impl HasLayout for Inverter {
+impl HasLayoutData for Inverter {
     type Data = ();
 }
 
-impl HasLayoutImpl<ExamplePdkA> for Inverter {
+impl HasLayout<ExamplePdkA> for Inverter {
     fn layout(
         &self,
         io: &mut <<Self as substrate::block::Block>::Io as substrate::io::LayoutType>::Builder,
@@ -60,7 +60,7 @@ impl HasLayoutImpl<ExamplePdkA> for Inverter {
     }
 }
 
-impl HasLayoutImpl<ExamplePdkB> for Inverter {
+impl HasLayout<ExamplePdkB> for Inverter {
     fn layout(
         &self,
         io: &mut <<Self as substrate::block::Block>::Io as substrate::io::LayoutType>::Builder,
@@ -160,12 +160,12 @@ pub struct BufferData {
     pub inv2: Instance<Inverter>,
 }
 
-impl HasLayout for Buffer {
+impl HasLayoutData for Buffer {
     type Data = BufferData;
 }
 
 #[impl_dispatch({ExamplePdkA; ExamplePdkB})]
-impl<PDK> HasLayoutImpl<PDK> for Buffer {
+impl<PDK> HasLayout<PDK> for Buffer {
     fn layout(
         &self,
         io: &mut <<Self as substrate::block::Block>::Io as substrate::io::LayoutType>::Builder,
@@ -213,12 +213,12 @@ pub struct BufferNData {
     pub buffers: Vec<Instance<Buffer>>,
 }
 
-impl HasLayout for BufferN {
+impl HasLayoutData for BufferN {
     type Data = BufferNData;
 }
 
 #[impl_dispatch({ExamplePdkA; ExamplePdkB})]
-impl<PDK> HasLayoutImpl<PDK> for BufferN {
+impl<PDK> HasLayout<PDK> for BufferN {
     fn layout(
         &self,
         io: &mut <<Self as substrate::block::Block>::Io as substrate::io::LayoutType>::Builder,
@@ -263,12 +263,12 @@ impl<PDK> HasLayoutImpl<PDK> for BufferN {
     }
 }
 
-impl HasLayout for BufferNxM {
+impl HasLayoutData for BufferNxM {
     type Data = ();
 }
 
 #[impl_dispatch({ExamplePdkA; ExamplePdkB})]
-impl<PDK> HasLayoutImpl<PDK> for BufferNxM {
+impl<PDK> HasLayout<PDK> for BufferNxM {
     fn layout(
         &self,
         io: &mut <<Self as substrate::block::Block>::Io as substrate::io::LayoutType>::Builder,


### PR DESCRIPTION
These traits have been renamed to `HasLayoutData`
and `HasLayout`, respectively.
