### PR TITLE
feat(io): composable port directions and runtime connection checking

### DIFF
--- a/libs/scir/src/lib.rs
+++ b/libs/scir/src/lib.rs
@@ -420,6 +420,27 @@ impl Direction {
             Self::InOut => Self::InOut,
         }
     }
+
+    /// Test if two nodes of the respective directions are allowed be connected
+    /// to each other.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scir::Direction;
+    /// assert_eq!(Direction::Input.is_compatible_with(Direction::Output), true);
+    /// assert_eq!(Direction::Output.is_compatible_with(Direction::Output), false);
+    /// assert_eq!(Direction::Output.is_compatible_with(Direction::InOut), true);
+    /// ```
+    pub fn is_compatible_with(&self, other: Direction) -> bool {
+        use Direction::*;
+
+        #[allow(clippy::match_like_matches_macro)]
+        match (*self, other) {
+            (Output, Output) => false,
+            _ => true,
+        }
+    }
 }
 
 /// A signal exposed by a cell.

--- a/libs/scir/src/lib.rs
+++ b/libs/scir/src/lib.rs
@@ -25,7 +25,7 @@
 #![warn(missing_docs)]
 
 use std::collections::HashMap;
-use std::fmt::Display;
+use std::fmt::{Display, Formatter};
 use std::ops::Deref;
 
 use arcstr::ArcStr;
@@ -439,6 +439,16 @@ impl Direction {
         match (*self, other) {
             (Output, Output) => false,
             _ => true,
+        }
+    }
+}
+
+impl Display for Direction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::Output => write!(f, "output"),
+            Self::Input => write!(f, "input"),
+            Self::InOut => write!(f, "inout"),
         }
     }
 }

--- a/pdks/sky130pdk/src/mos.rs
+++ b/pdks/sky130pdk/src/mos.rs
@@ -93,7 +93,7 @@ macro_rules! define_mos {
                 let l = Decimal::new(self.params.l, 3);
                 cell.add_primitive(substrate::schematic::PrimitiveDevice::from_params(
                     substrate::schematic::PrimitiveDeviceKind::RawInstance {
-                        ports: vec![*io.d, *io.g, *io.s, *io.b],
+                        ports: vec![io.d, io.g, io.s, io.b],
                         cell: arcstr::literal!(stringify!($opensubckt)),
                     },
                     HashMap::from_iter([
@@ -126,7 +126,7 @@ macro_rules! define_mos {
                 let l = Decimal::new(self.params.l, 3);
                 cell.add_primitive(substrate::schematic::PrimitiveDevice::from_params(
                     substrate::schematic::PrimitiveDeviceKind::RawInstance {
-                        ports: vec![*io.d, *io.g, *io.s, *io.b],
+                        ports: vec![io.d, io.g, io.s, io.b],
                         cell: arcstr::literal!(stringify!($comsubckt)),
                     },
                     HashMap::from_iter([

--- a/substrate/src/context.rs
+++ b/substrate/src/context.rs
@@ -434,13 +434,8 @@ fn prepare_cell_builder<PDK: Pdk, T: Block>(
     // block)
     let io_internal = Flipped(io_outward.clone());
     // FIXME: the cell's IO should not be attributed to this call site
-    let nodes = node_ctx.nodes_directed(
-        &io_internal.flatten_vec(),
-        NodePriority::Io,
-        SourceInfo::from_caller(),
-    );
-    let (io_data, nodes_rest) = io_internal.instantiate(&nodes);
-    assert!(nodes_rest.is_empty());
+    let (nodes, io_data) =
+        node_ctx.instantiate_directed(&io_internal, NodePriority::Io, SourceInfo::from_caller());
     let cell_name = block.name();
 
     let names = io_outward.flat_names(None);

--- a/substrate/src/diagnostics.rs
+++ b/substrate/src/diagnostics.rs
@@ -1,0 +1,30 @@
+// FIXME: unify crate with diagnostics crate?
+
+use std::{borrow::Cow, panic::Location};
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct SourceInfo {
+    // TODO: improve or replace with miette types
+    file: Cow<'static, str>,
+    line: u32,
+    column: u32,
+    length: Option<u32>,
+}
+
+impl SourceInfo {
+    /// Get a [`SourceInfo`] pointing to the caller of `from_caller`
+    ///
+    /// Like with [`Location::caller`], annotate functions with
+    /// `#[track_caller]` for `from_caller` to skip them when looking up the
+    /// call stack
+    #[track_caller]
+    pub fn from_caller() -> Self {
+        let loc = Location::caller();
+        SourceInfo {
+            file: loc.file().into(),
+            line: loc.line(),
+            column: loc.column(),
+            length: None,
+        }
+    }
+}

--- a/substrate/src/error.rs
+++ b/substrate/src/error.rs
@@ -8,7 +8,7 @@ use gds::GdsError;
 use crate::layout::error::{GdsImportError, LayoutError};
 
 /// A result type returning Substrate errors.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// The error type for Substrate functions.
 #[derive(thiserror::Error, Debug, Clone)]

--- a/substrate/src/io/impls.rs
+++ b/substrate/src/io/impls.rs
@@ -369,10 +369,10 @@ impl<T> SchematicType for Input<T>
 where
     T: SchematicType,
 {
-    type Data = Input<T::Data>;
+    type Data = T::Data;
     fn instantiate<'n>(&self, ids: &'n [Node]) -> (Self::Data, &'n [Node]) {
         let (data, ids) = self.0.instantiate(ids);
-        (Input(data), ids)
+        (data, ids)
     }
 }
 
@@ -439,10 +439,10 @@ impl<T> SchematicType for Output<T>
 where
     T: SchematicType,
 {
-    type Data = Output<T::Data>;
+    type Data = T::Data;
     fn instantiate<'n>(&self, ids: &'n [Node]) -> (Self::Data, &'n [Node]) {
         let (data, ids) = self.0.instantiate(ids);
-        (Output(data), ids)
+        (data, ids)
     }
 }
 
@@ -541,10 +541,10 @@ impl<T> SchematicType for InOut<T>
 where
     T: SchematicType,
 {
-    type Data = InOut<T::Data>;
+    type Data = T::Data;
     fn instantiate<'n>(&self, ids: &'n [Node]) -> (Self::Data, &'n [Node]) {
         let (data, ids) = self.0.instantiate(ids);
-        (InOut(data), ids)
+        (data, ids)
     }
 }
 
@@ -823,32 +823,6 @@ where
 impl<T> Connect<T> for T {}
 impl<T> Connect<&T> for T {}
 impl<T> Connect<T> for &T {}
-impl<T> Connect<T> for Input<T> {}
-impl<T> Connect<T> for Output<T> {}
-impl<T> Connect<T> for InOut<T> {}
-impl<T> Connect<Input<T>> for T {}
-impl<T> Connect<Output<T>> for T {}
-impl<T> Connect<InOut<T>> for T {}
-impl<T> Connect<&T> for &Input<T> {}
-impl<T> Connect<&T> for &Output<T> {}
-impl<T> Connect<&T> for &InOut<T> {}
-impl<T> Connect<&Input<T>> for &T {}
-impl<T> Connect<&Output<T>> for &T {}
-impl<T> Connect<&InOut<T>> for &T {}
-
-// For analog circuits, we don't check directionality of connections.
-impl<T> Connect<Input<T>> for Output<T> {}
-impl<T> Connect<Input<T>> for InOut<T> {}
-impl<T> Connect<Output<T>> for Input<T> {}
-impl<T> Connect<Output<T>> for InOut<T> {}
-impl<T> Connect<InOut<T>> for Input<T> {}
-impl<T> Connect<InOut<T>> for Output<T> {}
-impl<T> Connect<&Input<T>> for &Output<T> {}
-impl<T> Connect<&Input<T>> for &InOut<T> {}
-impl<T> Connect<&Output<T>> for &Input<T> {}
-impl<T> Connect<&Output<T>> for &InOut<T> {}
-impl<T> Connect<&InOut<T>> for &Input<T> {}
-impl<T> Connect<&InOut<T>> for &Output<T> {}
 
 impl From<ArcStr> for NameFragment {
     fn from(value: ArcStr) -> Self {

--- a/substrate/src/io/impls.rs
+++ b/substrate/src/io/impls.rs
@@ -47,8 +47,6 @@ impl Flatten<Direction> for () {
     }
 }
 
-impl Undirected for () {}
-
 impl SchematicType for () {
     type Data = ();
     fn instantiate<'n>(&self, ids: &'n [Node]) -> (Self::Data, &'n [Node]) {
@@ -123,8 +121,6 @@ impl HasNameTree for Signal {
     }
 }
 
-impl Undirected for Signal {}
-
 impl FlatLen for ShapePort {
     fn len(&self) -> usize {
         1
@@ -145,8 +141,6 @@ impl HasNameTree for ShapePort {
         Some(vec![])
     }
 }
-
-impl Undirected for ShapePort {}
 
 impl CustomLayoutType<Signal> for ShapePort {
     fn from_layout_type(_other: &Signal) -> Self {
@@ -174,8 +168,6 @@ impl HasNameTree for LayoutPort {
         Some(vec![])
     }
 }
-
-impl Undirected for LayoutPort {}
 
 impl CustomLayoutType<Signal> for LayoutPort {
     fn from_layout_type(_other: &Signal) -> Self {
@@ -220,8 +212,6 @@ impl HasNestedView for NestedNode {
     }
 }
 
-impl Undirected for Node {}
-
 impl FlatLen for NestedNode {
     fn len(&self) -> usize {
         1
@@ -256,8 +246,6 @@ impl Flatten<PortGeometry> for IoShape {
     }
 }
 
-impl Undirected for IoShape {}
-
 impl HierarchicalBuildFrom<NamedPorts> for OptionBuilder<IoShape> {
     fn build_from(&mut self, path: &mut NameBuf, source: &NamedPorts) {
         self.set(source.get(path).unwrap().primary.clone());
@@ -269,10 +257,6 @@ impl<T: LayoutData> LayoutDataBuilder<T> for OptionBuilder<T> {
         self.build()
     }
 }
-
-impl<T: Undirected> Undirected for OptionBuilder<T> {}
-
-impl<T: Undirected> Undirected for Option<T> {}
 
 impl FlatLen for PortGeometry {
     fn len(&self) -> usize {
@@ -319,8 +303,6 @@ impl HasTransformedView for PortGeometry {
     }
 }
 
-impl Undirected for PortGeometry {}
-
 impl FlatLen for PortGeometryBuilder {
     fn len(&self) -> usize {
         1
@@ -343,8 +325,6 @@ impl LayoutDataBuilder<PortGeometry> for PortGeometryBuilder {
     }
 }
 
-impl Undirected for PortGeometryBuilder {}
-
 impl HierarchicalBuildFrom<NamedPorts> for PortGeometryBuilder {
     fn build_from(&mut self, path: &mut NameBuf, source: &NamedPorts) {
         let source = source.get(path).unwrap();
@@ -354,32 +334,32 @@ impl HierarchicalBuildFrom<NamedPorts> for PortGeometryBuilder {
     }
 }
 
-impl<T: Undirected> AsRef<T> for Input<T> {
+impl<T> AsRef<T> for Input<T> {
     fn as_ref(&self) -> &T {
         &self.0
     }
 }
 
-impl<T: Undirected> Deref for Input<T> {
+impl<T> Deref for Input<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<T: Undirected> DerefMut for Input<T> {
+impl<T> DerefMut for Input<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<U: Undirected, T: From<U> + Undirected> From<U> for Input<T> {
-    fn from(value: U) -> Self {
-        Input(value.into())
+impl<T> From<T> for Input<T> {
+    fn from(value: T) -> Self {
+        Input(value)
     }
 }
 
-impl<T: Undirected> Borrow<T> for Input<T> {
+impl<T> Borrow<T> for Input<T> {
     fn borrow(&self) -> &T {
         &self.0
     }
@@ -387,8 +367,7 @@ impl<T: Undirected> Borrow<T> for Input<T> {
 
 impl<T> SchematicType for Input<T>
 where
-    T: Undirected + SchematicType,
-    T::Data: Undirected,
+    T: SchematicType,
 {
     type Data = Input<T::Data>;
     fn instantiate<'n>(&self, ids: &'n [Node]) -> (Self::Data, &'n [Node]) {
@@ -399,9 +378,7 @@ where
 
 impl<T> LayoutType for Input<T>
 where
-    T: Undirected + LayoutType,
-    T::Data: Undirected,
-    T::Builder: Undirected,
+    T: LayoutType,
 {
     type Data = T::Data;
     type Builder = T::Builder;
@@ -413,29 +390,27 @@ where
 
 impl<T, U: CustomLayoutType<T>> CustomLayoutType<Input<T>> for U
 where
-    T: Undirected + LayoutType,
-    T::Data: Undirected,
-    T::Builder: Undirected,
+    T: LayoutType,
 {
     fn from_layout_type(other: &Input<T>) -> Self {
         <U as CustomLayoutType<T>>::from_layout_type(&other.0)
     }
 }
 
-impl<T: Undirected + HasNameTree> HasNameTree for Input<T> {
+impl<T: HasNameTree> HasNameTree for Input<T> {
     fn names(&self) -> Option<Vec<NameTree>> {
         self.0.names()
     }
 }
 
-impl<T: Undirected + FlatLen> FlatLen for Input<T> {
+impl<T: FlatLen> FlatLen for Input<T> {
     #[inline]
     fn len(&self) -> usize {
         self.0.len()
     }
 }
 
-impl<T: Undirected + FlatLen> Flatten<Direction> for Input<T> {
+impl<T: FlatLen> Flatten<Direction> for Input<T> {
     fn flatten<E>(&self, output: &mut E)
     where
         E: Extend<Direction>,
@@ -443,7 +418,7 @@ impl<T: Undirected + FlatLen> Flatten<Direction> for Input<T> {
         output.extend(std::iter::repeat(Direction::Input).take(self.0.len()))
     }
 }
-impl<T: Undirected + Flatten<Node>> Flatten<Node> for Input<T> {
+impl<T: Flatten<Node>> Flatten<Node> for Input<T> {
     fn flatten<E>(&self, output: &mut E)
     where
         E: Extend<Node>,
@@ -452,7 +427,7 @@ impl<T: Undirected + Flatten<Node>> Flatten<Node> for Input<T> {
     }
 }
 
-impl<T: Undirected + HasNestedView> HasNestedView for Input<T> {
+impl<T: HasNestedView> HasNestedView for Input<T> {
     type NestedView<'a> = T::NestedView<'a> where T: 'a;
 
     fn nested_view(&self, parent: &InstancePath) -> Self::NestedView<'_> {
@@ -462,8 +437,7 @@ impl<T: Undirected + HasNestedView> HasNestedView for Input<T> {
 
 impl<T> SchematicType for Output<T>
 where
-    T: Undirected + SchematicType,
-    T::Data: Undirected,
+    T: SchematicType,
 {
     type Data = Output<T::Data>;
     fn instantiate<'n>(&self, ids: &'n [Node]) -> (Self::Data, &'n [Node]) {
@@ -474,9 +448,7 @@ where
 
 impl<T> LayoutType for Output<T>
 where
-    T: Undirected + LayoutType,
-    T::Data: Undirected,
-    T::Builder: Undirected,
+    T: LayoutType,
 {
     type Data = T::Data;
     type Builder = T::Builder;
@@ -488,29 +460,27 @@ where
 
 impl<T, U: CustomLayoutType<T>> CustomLayoutType<Output<T>> for U
 where
-    T: Undirected + LayoutType,
-    T::Data: Undirected,
-    T::Builder: Undirected,
+    T: LayoutType,
 {
     fn from_layout_type(other: &Output<T>) -> Self {
         <U as CustomLayoutType<T>>::from_layout_type(&other.0)
     }
 }
 
-impl<T: Undirected + HasNameTree> HasNameTree for Output<T> {
+impl<T: HasNameTree> HasNameTree for Output<T> {
     fn names(&self) -> Option<Vec<NameTree>> {
         self.0.names()
     }
 }
 
-impl<T: Undirected + FlatLen> FlatLen for Output<T> {
+impl<T: FlatLen> FlatLen for Output<T> {
     #[inline]
     fn len(&self) -> usize {
         self.0.len()
     }
 }
 
-impl<T: Undirected + FlatLen> Flatten<Direction> for Output<T> {
+impl<T: FlatLen> Flatten<Direction> for Output<T> {
     fn flatten<E>(&self, output: &mut E)
     where
         E: Extend<Direction>,
@@ -519,7 +489,7 @@ impl<T: Undirected + FlatLen> Flatten<Direction> for Output<T> {
     }
 }
 
-impl<T: Undirected + Flatten<Node>> Flatten<Node> for Output<T> {
+impl<T: Flatten<Node>> Flatten<Node> for Output<T> {
     fn flatten<E>(&self, output: &mut E)
     where
         E: Extend<Node>,
@@ -528,7 +498,7 @@ impl<T: Undirected + Flatten<Node>> Flatten<Node> for Output<T> {
     }
 }
 
-impl<T: Undirected + HasNestedView> HasNestedView for Output<T> {
+impl<T: HasNestedView> HasNestedView for Output<T> {
     type NestedView<'a> = T::NestedView<'a> where T: 'a;
 
     fn nested_view(&self, parent: &InstancePath) -> Self::NestedView<'_> {
@@ -536,32 +506,32 @@ impl<T: Undirected + HasNestedView> HasNestedView for Output<T> {
     }
 }
 
-impl<T: Undirected> AsRef<T> for Output<T> {
+impl<T> AsRef<T> for Output<T> {
     fn as_ref(&self) -> &T {
         &self.0
     }
 }
 
-impl<T: Undirected> Deref for Output<T> {
+impl<T> Deref for Output<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<T: Undirected> DerefMut for Output<T> {
+impl<T> DerefMut for Output<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<U: Undirected, T: From<U> + Undirected> From<U> for Output<T> {
-    fn from(value: U) -> Self {
-        Output(value.into())
+impl<T> From<T> for Output<T> {
+    fn from(value: T) -> Self {
+        Output(value)
     }
 }
 
-impl<T: Undirected> Borrow<T> for Output<T> {
+impl<T> Borrow<T> for Output<T> {
     fn borrow(&self) -> &T {
         &self.0
     }
@@ -569,8 +539,7 @@ impl<T: Undirected> Borrow<T> for Output<T> {
 
 impl<T> SchematicType for InOut<T>
 where
-    T: Undirected + SchematicType,
-    T::Data: Undirected,
+    T: SchematicType,
 {
     type Data = InOut<T::Data>;
     fn instantiate<'n>(&self, ids: &'n [Node]) -> (Self::Data, &'n [Node]) {
@@ -581,9 +550,7 @@ where
 
 impl<T> LayoutType for InOut<T>
 where
-    T: Undirected + LayoutType,
-    T::Data: Undirected,
-    T::Builder: Undirected,
+    T: LayoutType,
 {
     type Data = T::Data;
     type Builder = T::Builder;
@@ -595,28 +562,26 @@ where
 
 impl<T, U: CustomLayoutType<T>> CustomLayoutType<InOut<T>> for U
 where
-    T: Undirected + LayoutType,
-    T::Data: Undirected,
-    T::Builder: Undirected,
+    T: LayoutType,
 {
     fn from_layout_type(other: &InOut<T>) -> Self {
         <U as CustomLayoutType<T>>::from_layout_type(&other.0)
     }
 }
 
-impl<T: Undirected + HasNameTree> HasNameTree for InOut<T> {
+impl<T: HasNameTree> HasNameTree for InOut<T> {
     fn names(&self) -> Option<Vec<NameTree>> {
         self.0.names()
     }
 }
 
-impl<T: Undirected + FlatLen> FlatLen for InOut<T> {
+impl<T: FlatLen> FlatLen for InOut<T> {
     #[inline]
     fn len(&self) -> usize {
         self.0.len()
     }
 }
-impl<T: Undirected + FlatLen> Flatten<Direction> for InOut<T> {
+impl<T: FlatLen> Flatten<Direction> for InOut<T> {
     fn flatten<E>(&self, output: &mut E)
     where
         E: Extend<Direction>,
@@ -624,7 +589,7 @@ impl<T: Undirected + FlatLen> Flatten<Direction> for InOut<T> {
         output.extend(std::iter::repeat(Direction::Input).take(self.0.len()))
     }
 }
-impl<T: Undirected + Flatten<Node>> Flatten<Node> for InOut<T> {
+impl<T: Flatten<Node>> Flatten<Node> for InOut<T> {
     fn flatten<E>(&self, output: &mut E)
     where
         E: Extend<Node>,
@@ -633,7 +598,7 @@ impl<T: Undirected + Flatten<Node>> Flatten<Node> for InOut<T> {
     }
 }
 
-impl<T: Undirected + SchematicData + HasNestedView> HasNestedView for InOut<T> {
+impl<T: SchematicData + HasNestedView> HasNestedView for InOut<T> {
     type NestedView<'a> = T::NestedView<'a> where T: 'a;
 
     fn nested_view(&self, parent: &InstancePath) -> Self::NestedView<'_> {
@@ -641,31 +606,31 @@ impl<T: Undirected + SchematicData + HasNestedView> HasNestedView for InOut<T> {
     }
 }
 
-impl<T: Undirected> AsRef<T> for InOut<T> {
+impl<T> AsRef<T> for InOut<T> {
     fn as_ref(&self) -> &T {
         &self.0
     }
 }
-impl<T: Undirected> Deref for InOut<T> {
+impl<T> Deref for InOut<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<T: Undirected> DerefMut for InOut<T> {
+impl<T> DerefMut for InOut<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<U: Undirected, T: From<U> + Undirected> From<U> for InOut<T> {
-    fn from(value: U) -> Self {
-        InOut(value.into())
+impl<T> From<T> for InOut<T> {
+    fn from(value: T) -> Self {
+        InOut(value)
     }
 }
 
-impl<T: Undirected> Borrow<T> for InOut<T> {
+impl<T> Borrow<T> for InOut<T> {
     fn borrow(&self) -> &T {
         &self.0
     }
@@ -795,8 +760,6 @@ impl<T: Flatten<Direction>> Flatten<Direction> for Array<T> {
     }
 }
 
-impl<T: Undirected> Undirected for Array<T> {}
-
 impl<T: FlatLen> FlatLen for ArrayData<T> {
     fn len(&self) -> usize {
         self.elems.len() * self.ty_len
@@ -857,37 +820,35 @@ where
     }
 }
 
-impl<T: Undirected> Undirected for ArrayData<T> {}
-
 impl<T> Connect<T> for T {}
 impl<T> Connect<&T> for T {}
 impl<T> Connect<T> for &T {}
-impl<T: Undirected> Connect<T> for Input<T> {}
-impl<T: Undirected> Connect<T> for Output<T> {}
-impl<T: Undirected> Connect<T> for InOut<T> {}
-impl<T: Undirected> Connect<Input<T>> for T {}
-impl<T: Undirected> Connect<Output<T>> for T {}
-impl<T: Undirected> Connect<InOut<T>> for T {}
-impl<T: Undirected> Connect<&T> for &Input<T> {}
-impl<T: Undirected> Connect<&T> for &Output<T> {}
-impl<T: Undirected> Connect<&T> for &InOut<T> {}
-impl<T: Undirected> Connect<&Input<T>> for &T {}
-impl<T: Undirected> Connect<&Output<T>> for &T {}
-impl<T: Undirected> Connect<&InOut<T>> for &T {}
+impl<T> Connect<T> for Input<T> {}
+impl<T> Connect<T> for Output<T> {}
+impl<T> Connect<T> for InOut<T> {}
+impl<T> Connect<Input<T>> for T {}
+impl<T> Connect<Output<T>> for T {}
+impl<T> Connect<InOut<T>> for T {}
+impl<T> Connect<&T> for &Input<T> {}
+impl<T> Connect<&T> for &Output<T> {}
+impl<T> Connect<&T> for &InOut<T> {}
+impl<T> Connect<&Input<T>> for &T {}
+impl<T> Connect<&Output<T>> for &T {}
+impl<T> Connect<&InOut<T>> for &T {}
 
 // For analog circuits, we don't check directionality of connections.
-impl<T: Undirected> Connect<Input<T>> for Output<T> {}
-impl<T: Undirected> Connect<Input<T>> for InOut<T> {}
-impl<T: Undirected> Connect<Output<T>> for Input<T> {}
-impl<T: Undirected> Connect<Output<T>> for InOut<T> {}
-impl<T: Undirected> Connect<InOut<T>> for Input<T> {}
-impl<T: Undirected> Connect<InOut<T>> for Output<T> {}
-impl<T: Undirected> Connect<&Input<T>> for &Output<T> {}
-impl<T: Undirected> Connect<&Input<T>> for &InOut<T> {}
-impl<T: Undirected> Connect<&Output<T>> for &Input<T> {}
-impl<T: Undirected> Connect<&Output<T>> for &InOut<T> {}
-impl<T: Undirected> Connect<&InOut<T>> for &Input<T> {}
-impl<T: Undirected> Connect<&InOut<T>> for &Output<T> {}
+impl<T> Connect<Input<T>> for Output<T> {}
+impl<T> Connect<Input<T>> for InOut<T> {}
+impl<T> Connect<Output<T>> for Input<T> {}
+impl<T> Connect<Output<T>> for InOut<T> {}
+impl<T> Connect<InOut<T>> for Input<T> {}
+impl<T> Connect<InOut<T>> for Output<T> {}
+impl<T> Connect<&Input<T>> for &Output<T> {}
+impl<T> Connect<&Input<T>> for &InOut<T> {}
+impl<T> Connect<&Output<T>> for &Input<T> {}
+impl<T> Connect<&Output<T>> for &InOut<T> {}
+impl<T> Connect<&InOut<T>> for &Input<T> {}
+impl<T> Connect<&InOut<T>> for &Output<T> {}
 
 impl From<ArcStr> for NameFragment {
     fn from(value: ArcStr) -> Self {

--- a/substrate/src/io/mod.rs
+++ b/substrate/src/io/mod.rs
@@ -548,8 +548,13 @@ impl NodeContext {
             .flat_map(|e1| n2_connections_data.drivers.iter().map(move |e2| [e1, e2]))
             .filter(|[(&k1, _), (&k2, _)]| !k1.is_compatible_with(k2))
             .collect();
+        let mut result = Ok(());
         if !incompatible_drivers.is_empty() {
-            return Err(NodeConnectDirectionError {
+            // If drivers are not compatible, return an error but connect them
+            // anyways, because (1) we would like to detect further errors
+            // that may be caused by the connection being made and (2) the
+            // error might be spurious and waived by the user.
+            result = Err(NodeConnectDirectionError {
                 data: incompatible_drivers
                     .iter()
                     .map(|&[(&k1, v1), (&k2, v2)]| [(k1, v1.clone()), (k2, v2.clone())])
@@ -578,7 +583,7 @@ impl NodeContext {
             .expect("new root should be populated")
             .merge_from(old_connections_data);
 
-        Ok(())
+        result
     }
 }
 

--- a/substrate/src/io/mod.rs
+++ b/substrate/src/io/mod.rs
@@ -41,9 +41,6 @@ pub trait Io: Directed + SchematicType + LayoutType {
 pub trait Directed: Flatten<Direction> {}
 impl<T: Flatten<Direction>> Directed for T {}
 
-/// A marker trait indicating that a hardware type does not specify signal directions.
-pub trait Undirected {}
-
 /// Flatten a structure into a list.
 pub trait Flatten<T>: FlatLen {
     /// Flatten a structure into a list.
@@ -197,15 +194,21 @@ pub struct NameTree {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default, Serialize, Deserialize)]
 /// An input port of hardware type `T`.
-pub struct Input<T: Undirected>(pub T);
+///
+/// Recursively overrides the direction of all components of `T` to be [`Input`](Direction::Input)
+pub struct Input<T>(pub T);
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default, Serialize, Deserialize)]
 /// An output port of hardware type `T`.
-pub struct Output<T: Undirected>(pub T);
+///
+/// Recursively overrides the direction of all components of `T` to be [`Output`](Direction::Output)
+pub struct Output<T>(pub T);
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default, Serialize, Deserialize)]
 /// An inout port of hardware type `T`.
-pub struct InOut<T: Undirected>(pub T);
+///
+/// Recursively overrides the direction of all components of `T` to be [`InOut`](Direction::InOut)
+pub struct InOut<T>(pub T);
 
 /// A type representing a single hardware wire.
 #[derive(Debug, Default, Clone, Copy)]

--- a/substrate/src/lib.rs
+++ b/substrate/src/lib.rs
@@ -24,6 +24,8 @@ pub mod pdk;
 pub mod schematic;
 pub mod simulation;
 
+mod diagnostics;
+
 // Re-exported for procedural macros.
 #[doc(hidden)]
 pub use arcstr;

--- a/substrate/src/schematic/mod.rs
+++ b/substrate/src/schematic/mod.rs
@@ -362,7 +362,10 @@ impl<PDK: Pdk, T: Block> CellBuilder<PDK, T> {
         s1f.into_iter().zip(s2f).for_each(|(a, b)| {
             // FIXME: proper error handling mechanism (collect all errors into
             // context and emit later)
-            self.node_ctx.connect(a, b).unwrap();
+            let res = self.node_ctx.connect(a, b);
+            if let Err(err) = res {
+                tracing::warn!(?err, "connection failed");
+            }
         });
     }
 

--- a/tests/src/derive/io.rs
+++ b/tests/src/derive/io.rs
@@ -1,8 +1,6 @@
 //! Tests for ensuring that `#[derive(Io)]` works.
 
-use substrate::io::{
-    HierarchicalBuildFrom, Input, LayoutType, Output, SchematicType, Signal, Undirected,
-};
+use substrate::io::{HierarchicalBuildFrom, Input, LayoutType, Output, SchematicType, Signal};
 use substrate::layout::element::NamedPorts;
 use substrate::Io;
 
@@ -10,10 +8,8 @@ use substrate::Io;
 #[derive(Debug, Clone, Io)]
 pub struct GenericIo<T>
 where
-    T: Clone + Undirected + SchematicType + LayoutType + 'static,
-    <T as SchematicType>::Data: Undirected,
-    <T as LayoutType>::Data: Undirected,
-    <T as LayoutType>::Builder: Undirected + HierarchicalBuildFrom<NamedPorts>,
+    T: Clone + SchematicType + LayoutType + 'static,
+    <T as LayoutType>::Builder: HierarchicalBuildFrom<NamedPorts>,
 {
     /// A single input field.
     pub signal: Input<T>,

--- a/tests/src/shared/buffer/schematic.rs
+++ b/tests/src/shared/buffer/schematic.rs
@@ -40,7 +40,7 @@ impl HasSchematic<ExamplePdkA> for Inverter {
 
         cell.connect(io.vdd, pmos_io.s);
         cell.connect(io.vss, nmos.s);
-        Ok(InverterData { din: *io.din, pmos })
+        Ok(InverterData { din: io.din, pmos })
     }
 }
 

--- a/tests/src/shared/pdk/mod.rs
+++ b/tests/src/shared/pdk/mod.rs
@@ -64,7 +64,7 @@ impl HasSchematic<ExamplePdkA> for NmosA {
     ) -> substrate::error::Result<Self::Data> {
         cell.add_primitive(PrimitiveDevice::from_params(
             PrimitiveDeviceKind::RawInstance {
-                ports: vec![*io.d, *io.g, *io.s, *io.b],
+                ports: vec![io.d, io.g, io.s, io.b],
                 cell: arcstr::literal!("example_pdk_nmos_a"),
             },
             HashMap::from_iter([
@@ -108,7 +108,7 @@ impl HasSchematic<ExamplePdkA> for PmosA {
     ) -> substrate::error::Result<Self::Data> {
         cell.add_primitive(PrimitiveDevice::from_params(
             PrimitiveDeviceKind::RawInstance {
-                ports: vec![*io.d, *io.g, *io.s, *io.b],
+                ports: vec![io.d, io.g, io.s, io.b],
                 cell: arcstr::literal!("example_pdk_pmos_a"),
             },
             HashMap::from_iter([

--- a/tests/src/shared/vdivider/flattened.rs
+++ b/tests/src/shared/vdivider/flattened.rs
@@ -90,8 +90,8 @@ impl<PDK: Pdk> HasSchematic<PDK> for Resistor {
     ) -> substrate::error::Result<Self::Data> {
         cell.add_primitive(
             PrimitiveDeviceKind::Res2 {
-                pos: *io.p,
-                neg: *io.n,
+                pos: io.p,
+                neg: io.n,
                 value: self.value,
             }
             .into(),

--- a/tests/src/shared/vdivider/mod.rs
+++ b/tests/src/shared/vdivider/mod.rs
@@ -157,8 +157,8 @@ impl<PDK: Pdk> HasSchematic<PDK> for Resistor {
     ) -> substrate::error::Result<Self::Data> {
         cell.add_primitive(
             PrimitiveDeviceKind::Res2 {
-                pos: *io.p,
-                neg: *io.n,
+                pos: io.p,
+                neg: io.n,
                 value: self.value,
             }
             .into(),

--- a/tools/spectre/src/blocks.rs
+++ b/tools/spectre/src/blocks.rs
@@ -110,7 +110,7 @@ impl<PDK: Pdk> HasSimSchematic<PDK, Spectre> for Vsource {
         cell.add_primitive(PrimitiveDevice::from_params(
             PrimitiveDeviceKind::RawInstance {
                 cell: arcstr::literal!("vsource"),
-                ports: vec![*io.p, *io.n],
+                ports: vec![io.p, io.n],
             },
             params,
         ));
@@ -150,7 +150,7 @@ impl<PDK: Pdk> HasSimSchematic<PDK, Spectre> for Iprobe {
     ) -> substrate::error::Result<Self::Data> {
         cell.add_primitive(PrimitiveDevice::new(PrimitiveDeviceKind::RawInstance {
             cell: arcstr::literal!("iprobe"),
-            ports: vec![*io.p, *io.n],
+            ports: vec![io.p, io.n],
         }));
         Ok(())
     }


### PR DESCRIPTION
Remove the `Undirected` marker trait, and make direction-setting wrappers like `Input<T>` act as an override to the direction of their contained type (instead of direction being a property that can only be set once).

Since there is no way to propagate direction down the hierarchy (so that e.g. `foo.bar` has the correct direction at type level when `foo` is wrapped in Input), remove direction information completely from the type level on instantiated data types.

Replace the `Connect` trait based type checking for directions with a fully runtime-based solution, which also allows for more accurate tracking (i.e. if `a` and `c` are `Output`, and `b` is `Input`, detect `a <> b` and `b <> c` as a multi-driven net). Also capture source info for debugging the cause of these connections.

TODO:
- [x] remove `Undirected`
- [x] runtime connection checking
- [ ] diagnostic info capture and reporting for bad connections (punt to later PR)

---

Due to coherence rules, the transitive `From` implementation for the wrappers had to be dropped (previously, if `T: From<U>`, then `Input<T>: From<U>`). This is because a user could implement `T: From<Input<T>>`, which would cause our blanket implementation to apply for `Input<T>: From<Input<T>>`, conflicting with std's blanket impl.

---

Closes #214