### PR TITLE
feat(parameters): substrate schematic primitives support parameters

### DIFF
--- a/codegen/src/block/schematic.rs
+++ b/codegen/src/block/schematic.rs
@@ -337,12 +337,14 @@ impl ToTokens for HasSchematicInputReceiver {
                                 (f, nodes)
                             }));
 
-                        cell.add_primitive(#substrate::schematic::PrimitiveDevice::ScirInstance {
-                            lib,
-                            cell: cell_id,
-                            name: #substrate::arcstr::literal!(#name),
-                            connections,
-                        });
+                        cell.add_primitive(#substrate::schematic::PrimitiveDevice::new(
+                            #substrate::schematic::PrimitiveDeviceKind::ScirInstance {
+                                lib,
+                                cell: cell_id,
+                                name: #substrate::arcstr::literal!(#name),
+                                connections,
+                            }
+                        ));
                         Ok(())
                     }
                 }

--- a/pdks/sky130pdk/src/mos.rs
+++ b/pdks/sky130pdk/src/mos.rs
@@ -91,10 +91,12 @@ macro_rules! define_mos {
                 // Convert from DB units to microns.
                 let w = Decimal::new(self.params.w, 3);
                 let l = Decimal::new(self.params.l, 3);
-                cell.add_primitive(substrate::schematic::PrimitiveDevice::RawInstance {
-                    ports: vec![*io.d, *io.g, *io.s, *io.b],
-                    cell: arcstr::literal!(stringify!($opensubckt)),
-                    params: HashMap::from_iter([
+                cell.add_primitive(substrate::schematic::PrimitiveDevice::from_params(
+                    substrate::schematic::PrimitiveDeviceKind::RawInstance {
+                        ports: vec![*io.d, *io.g, *io.s, *io.b],
+                        cell: arcstr::literal!(stringify!($opensubckt)),
+                    },
+                    HashMap::from_iter([
                         (
                             arcstr::literal!("w"),
                             substrate::scir::Expr::NumericLiteral(w),
@@ -108,7 +110,7 @@ macro_rules! define_mos {
                             substrate::scir::Expr::NumericLiteral(self.params.nf.into()),
                         ),
                     ]),
-                });
+                ));
                 Ok(())
             }
         }
@@ -122,10 +124,12 @@ macro_rules! define_mos {
                 // Convert from DB units to microns.
                 let w = Decimal::new(self.params.w, 3);
                 let l = Decimal::new(self.params.l, 3);
-                cell.add_primitive(substrate::schematic::PrimitiveDevice::RawInstance {
-                    ports: vec![*io.d, *io.g, *io.s, *io.b],
-                    cell: arcstr::literal!(stringify!($comsubckt)),
-                    params: HashMap::from_iter([
+                cell.add_primitive(substrate::schematic::PrimitiveDevice::from_params(
+                    substrate::schematic::PrimitiveDeviceKind::RawInstance {
+                        ports: vec![*io.d, *io.g, *io.s, *io.b],
+                        cell: arcstr::literal!(stringify!($comsubckt)),
+                    },
+                    HashMap::from_iter([
                         (
                             arcstr::literal!("w"),
                             substrate::scir::Expr::NumericLiteral(w),
@@ -139,7 +143,7 @@ macro_rules! define_mos {
                             substrate::scir::Expr::NumericLiteral(self.params.nf.into()),
                         ),
                     ]),
-                });
+                ));
                 Ok(())
             }
         }

--- a/substrate/src/schematic/mod.rs
+++ b/substrate/src/schematic/mod.rs
@@ -813,7 +813,16 @@ impl<T: HasSchematicData> Instance<T> {
 
 /// A primitive device.
 #[derive(Debug, Clone)]
-pub enum PrimitiveDevice {
+pub struct PrimitiveDevice {
+    /// The kind (resistor, capacitor, etc.) of this primitive device.
+    kind: PrimitiveDeviceKind,
+    /// An unordered set of parameters, represented as key-value pairs.
+    params: HashMap<ArcStr, scir::Expr>,
+}
+
+/// An enumeration of the possible kinds of primitive devices.
+#[derive(Debug, Clone)]
+pub enum PrimitiveDeviceKind {
     /// An ideal 2-terminal resistor.
     Res2 {
         /// The positive node.
@@ -831,8 +840,6 @@ pub enum PrimitiveDevice {
         ports: Vec<Node>,
         /// The name of the cell being instantiated.
         cell: ArcStr,
-        /// Parameters to the cell being instantiated.
-        params: HashMap<ArcStr, scir::Expr>,
     },
     /// An instance of a SCIR cell.
     ///
@@ -850,6 +857,42 @@ pub enum PrimitiveDevice {
         /// The connections to the ports of the child cell.
         connections: HashMap<ArcStr, Vec<Node>>,
     },
+}
+
+impl PrimitiveDevice {
+    /// Create a new primitive device with the given parameters.
+    #[inline]
+    pub fn from_params(
+        kind: PrimitiveDeviceKind,
+        params: impl Into<HashMap<ArcStr, scir::Expr>>,
+    ) -> Self {
+        Self {
+            kind,
+            params: params.into(),
+        }
+    }
+
+    /// Create a new primitive device with no parameters.
+    #[inline]
+    pub fn new(kind: PrimitiveDeviceKind) -> Self {
+        Self {
+            kind,
+            params: Default::default(),
+        }
+    }
+}
+
+impl From<PrimitiveDeviceKind> for PrimitiveDevice {
+    #[inline]
+    fn from(value: PrimitiveDeviceKind) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<PrimitiveDevice> for PrimitiveDeviceKind {
+    fn from(value: PrimitiveDevice) -> Self {
+        value.kind
+    }
 }
 
 /// A wrapper around schematic-specific context data.

--- a/tests/src/shared/pdk/mod.rs
+++ b/tests/src/shared/pdk/mod.rs
@@ -8,7 +8,7 @@ use substrate::block::Block;
 use substrate::context::Context;
 use substrate::io::MosIo;
 use substrate::pdk::Pdk;
-use substrate::schematic::{HasSchematic, HasSchematicData, PrimitiveDevice};
+use substrate::schematic::{HasSchematic, HasSchematicData, PrimitiveDevice, PrimitiveDeviceKind};
 use substrate::Corner;
 
 use self::layers::{ExamplePdkALayers, ExamplePdkBLayers};
@@ -62,14 +62,16 @@ impl HasSchematic<ExamplePdkA> for NmosA {
         io: &<<Self as Block>::Io as substrate::io::SchematicType>::Data,
         cell: &mut substrate::schematic::CellBuilder<ExamplePdkA, Self>,
     ) -> substrate::error::Result<Self::Data> {
-        cell.add_primitive(PrimitiveDevice::RawInstance {
-            ports: vec![*io.d, *io.g, *io.s, *io.b],
-            cell: arcstr::literal!("example_pdk_nmos_a"),
-            params: HashMap::from_iter([
+        cell.add_primitive(PrimitiveDevice::from_params(
+            PrimitiveDeviceKind::RawInstance {
+                ports: vec![*io.d, *io.g, *io.s, *io.b],
+                cell: arcstr::literal!("example_pdk_nmos_a"),
+            },
+            HashMap::from_iter([
                 (arcstr::literal!("w"), Expr::NumericLiteral(self.w.into())),
                 (arcstr::literal!("l"), Expr::NumericLiteral(self.l.into())),
             ]),
-        });
+        ));
         Ok(())
     }
 }
@@ -104,14 +106,16 @@ impl HasSchematic<ExamplePdkA> for PmosA {
         io: &<<Self as Block>::Io as substrate::io::SchematicType>::Data,
         cell: &mut substrate::schematic::CellBuilder<ExamplePdkA, Self>,
     ) -> substrate::error::Result<Self::Data> {
-        cell.add_primitive(PrimitiveDevice::RawInstance {
-            ports: vec![*io.d, *io.g, *io.s, *io.b],
-            cell: arcstr::literal!("example_pdk_pmos_a"),
-            params: HashMap::from_iter([
+        cell.add_primitive(PrimitiveDevice::from_params(
+            PrimitiveDeviceKind::RawInstance {
+                ports: vec![*io.d, *io.g, *io.s, *io.b],
+                cell: arcstr::literal!("example_pdk_pmos_a"),
+            },
+            HashMap::from_iter([
                 (arcstr::literal!("w"), Expr::NumericLiteral(self.w.into())),
                 (arcstr::literal!("l"), Expr::NumericLiteral(self.l.into())),
             ]),
-        });
+        ));
         Ok(())
     }
 }

--- a/tests/src/shared/vdivider/flattened.rs
+++ b/tests/src/shared/vdivider/flattened.rs
@@ -3,9 +3,7 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use substrate::block::Block;
 use substrate::pdk::Pdk;
-use substrate::schematic::{
-    CellBuilder, HasSchematic, HasSchematicData, Instance, PrimitiveDevice,
-};
+use substrate::schematic::{CellBuilder, HasSchematic, HasSchematicData, Instance};
 use substrate::Block;
 use substrate::SchematicData;
 
@@ -90,11 +88,14 @@ impl<PDK: Pdk> HasSchematic<PDK> for Resistor {
         io: &ResistorIoSchematic,
         cell: &mut CellBuilder<PDK, Self>,
     ) -> substrate::error::Result<Self::Data> {
-        cell.add_primitive(PrimitiveDevice::Res2 {
-            pos: *io.p,
-            neg: *io.n,
-            value: self.value,
-        });
+        cell.add_primitive(
+            PrimitiveDeviceKind::Res2 {
+                pos: *io.p,
+                neg: *io.n,
+                value: self.value,
+            }
+            .into(),
+        );
         Ok(())
     }
 }

--- a/tests/src/shared/vdivider/mod.rs
+++ b/tests/src/shared/vdivider/mod.rs
@@ -5,7 +5,7 @@ use substrate::block::Block;
 use substrate::io::{Array, InOut, Output, Signal};
 use substrate::pdk::Pdk;
 use substrate::schematic::{
-    CellBuilder, HasSchematic, HasSchematicData, Instance, PrimitiveDevice,
+    CellBuilder, HasSchematic, HasSchematicData, Instance, PrimitiveDeviceKind,
 };
 use substrate::{Io, SchematicData};
 
@@ -155,11 +155,14 @@ impl<PDK: Pdk> HasSchematic<PDK> for Resistor {
         io: &ResistorIoSchematic,
         cell: &mut CellBuilder<PDK, Self>,
     ) -> substrate::error::Result<Self::Data> {
-        cell.add_primitive(PrimitiveDevice::Res2 {
-            pos: *io.p,
-            neg: *io.n,
-            value: self.value,
-        });
+        cell.add_primitive(
+            PrimitiveDeviceKind::Res2 {
+                pos: *io.p,
+                neg: *io.n,
+                value: self.value,
+            }
+            .into(),
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
feat(spectre): vsource uses primitives instead of being blackboxed
