### PR TITLE
feat(ios): panic when shorting IOs

### DIFF
--- a/substrate/src/io/mod.rs
+++ b/substrate/src/io/mod.rs
@@ -300,6 +300,9 @@ impl ena::unify::UnifyValue for NodeUfValue {
     type Error = ena::unify::NoError;
 
     fn unify_values(value1: &Self, value2: &Self) -> std::result::Result<Self, Self::Error> {
+        if value1.priority == NodePriority::Io && value2.priority == NodePriority::Io && value1.source != value2.source {
+            panic!("shorted IOs are not supported")
+        }
         Ok(if value1.priority >= value2.priority {
             *value1
         } else {

--- a/tests/src/shared/array_short.rs
+++ b/tests/src/shared/array_short.rs
@@ -2,10 +2,12 @@ use arcstr::ArcStr;
 use serde::{Deserialize, Serialize};
 use substrate::io::*;
 use substrate::schematic::*;
+use test_log::test;
 
 use substrate::pdk::Pdk;
 use substrate::Io;
 use substrate::{block::Block, schematic::HasSchematic};
+use crate::shared::pdk::sky130_open_ctx;
 
 #[derive(Debug, Clone, Io)]
 pub struct ArrayIo {
@@ -51,4 +53,13 @@ impl<PDK: Pdk> HasSchematic<PDK> for ArrayShort {
         }
         Ok(())
     }
+}
+
+#[test]
+#[should_panic]
+fn panics_when_shorting_ios() {
+    let ctx = sky130_open_ctx();
+    let _ = ctx.export_scir(ArrayShort {
+        width: 5,
+    });
 }


### PR DESCRIPTION
Until we implement schematic short propagation,
shorting IOs in a schematic generator should be a hard error.
